### PR TITLE
Add external transcript support and language detection

### DIFF
--- a/.claude/skills/analyze-video/SKILL.md
+++ b/.claude/skills/analyze-video/SKILL.md
@@ -45,9 +45,13 @@ Set up the output directory:
 mkdir -p .video2pr/<video-basename>
 ```
 
-## Phase 3: Extract Audio & Transcribe
+**Check for external transcript:** Search for transcript files in the same directory as the video, matching the video basename with extensions: `.sbv`, `.vtt`, `.txt`, `.docx`. Also accept a user-provided transcript path. If found, report: "Found external transcript: meeting.vtt (MS Teams VTT format)"
 
-Run within the `video2pr` conda environment:
+## Phase 3: Extract & Transcribe
+
+### Phase 3a: Extract Audio
+
+Always extract audio (needed for language detection even with external transcripts):
 
 ```bash
 conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/extract_audio.py \
@@ -55,20 +59,60 @@ conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/extract_audio.py \
   --output-dir ".video2pr/<video-basename>"
 ```
 
-```bash
-conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/transcribe.py \
-  --input ".video2pr/<video-basename>/audio.wav" \
-  --output-dir ".video2pr/<video-basename>" \
-  --model base
-```
+### Phase 3b: Check for External Transcript
+
+If an external transcript was found in Phase 2:
+
+- **With timestamps** → Convert and skip Whisper, go to Phase 3d:
+  ```bash
+  conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/convert_transcript.py \
+    --input "<transcript-path>" \
+    --output-dir ".video2pr/<video-basename>"
+  ```
+
+- **Without timestamps** → Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
+  ```bash
+  conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/convert_transcript.py \
+    --input "<transcript-path>" \
+    --output-dir ".video2pr/<video-basename>"
+  ```
+
+If no external transcript → continue to Phase 3c.
+
+### Phase 3c: Language Detection + Whisper Transcription
+
+1. Detect language (always uses base model for speed):
+   ```bash
+   conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/transcribe.py \
+     --input ".video2pr/<video-basename>/audio.wav" \
+     --detect-language
+   ```
+   Report: "Detected language: English (95% confidence)"
+
+2. If confidence < 80%, ask the user to confirm the language before proceeding.
+
+3. Run full transcription with the confirmed language:
+   ```bash
+   conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/transcribe.py \
+     --input ".video2pr/<video-basename>/audio.wav" \
+     --output-dir ".video2pr/<video-basename>" \
+     --model base \
+     --language <confirmed-language-code>
+   ```
 
 For higher accuracy (longer processing), use `--model medium` or `--model large`.
+
+### Phase 3d: Speaker Enrichment (conditional)
+
+If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done by Claude directly (no script needed) — compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
 
 ## Phase 4: Analyze Transcript
 
 Read `.video2pr/<video-basename>/transcript.json`. This file contains:
-- **Segments**: each with `start` (float seconds), `end` (float seconds), `text`
-- **Words**: within each segment, entries with `word`, `start`, `end`, `probability`
+- **Segments**: each with `start` (float seconds), `end` (float seconds), `text`, optionally `speaker`
+- **Words**: within each segment, entries with `word`, `start`, `end`, `probability` (may be empty for external transcripts)
+
+When `speaker` fields are available, use them to attribute topics, action items, and decisions to specific speakers.
 
 Analyze the transcript to identify:
 
@@ -133,6 +177,8 @@ The frame is saved to `.video2pr/<video-basename>/frames/frame_00h03m22s.png` an
 After completion, confirm these files exist in `.video2pr/<video-basename>/`:
 - `audio.wav` — 16kHz mono audio
 - `metadata.json` — ffprobe video metadata
-- `transcript.srt` — SRT transcript with timestamps
-- `transcript.json` — JSON with word-level timestamps
+- `transcript.json` — JSON with segment timestamps (and word-level if Whisper-generated)
+- `transcript.srt` — SRT transcript with timestamps (Whisper-generated only)
 - `summary.md` — structured meeting analysis
+- `external_transcript_meta.json` — (if external transcript used) source format and capabilities
+- `external_transcript_original.*` — (if external transcript used) copy of original file

--- a/.claude/skills/analyze-video/scripts/check_deps.py
+++ b/.claude/skills/analyze-video/scripts/check_deps.py
@@ -29,11 +29,23 @@ def check_conda_env(env_name):
     return False
 
 
+def check_python_import(module_name):
+    """Check if a Python module can be imported."""
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
 def main():
     deps = {
         "ffmpeg": check_command("ffmpeg"),
         "ffprobe": check_command("ffprobe"),
         "whisper": check_command("whisper"),
+    }
+    pip_deps = {
+        "python-docx": check_python_import("docx"),
     }
     conda_ok = check_conda_env("video2pr")
 
@@ -41,10 +53,14 @@ def main():
     for name, found in deps.items():
         status = "OK" if found else "MISSING"
         print(f"  {name}: {status}")
+    for name, found in pip_deps.items():
+        status = "OK" if found else "MISSING"
+        print(f"  {name}: {status}")
 
     print(f"  conda env (video2pr): {'OK' if conda_ok else 'MISSING'}")
 
     missing = [name for name, found in deps.items() if not found]
+    missing.extend(name for name, found in pip_deps.items() if not found)
     if not conda_ok:
         missing.append("conda env (video2pr)")
 

--- a/.claude/skills/analyze-video/scripts/convert_transcript.py
+++ b/.claude/skills/analyze-video/scripts/convert_transcript.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Parse external transcripts (Google Meet, MS Teams) into canonical JSON format."""
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+def detect_format(input_path: Path) -> str:
+    """Auto-detect transcript format from extension and content patterns."""
+    ext = input_path.suffix.lower()
+
+    if ext == ".docx":
+        return "teams_docx"
+    if ext == ".sbv":
+        return "sbv"
+
+    content = input_path.read_text(encoding="utf-8", errors="replace")
+
+    if ext == ".vtt" or content.strip().startswith("WEBVTT"):
+        return "vtt"
+
+    # Google Meet .txt: lines like "Speaker Name (0:12:34)"
+    if re.search(r"^.+ \(\d+:\d+:\d+\)$", content, re.MULTILINE):
+        return "google_txt"
+
+    # SBV pattern: "0:00:01.234,0:00:05.678"
+    if re.search(r"^\d+:\d+:\d+\.\d+,", content, re.MULTILINE):
+        return "sbv"
+
+    print(f"Could not detect transcript format for {input_path}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_sbv_timestamp(ts: str) -> float:
+    """Parse SBV timestamp (H:MM:SS.mmm) to seconds."""
+    match = re.match(r"(\d+):(\d+):(\d+)\.(\d+)", ts.strip())
+    if not match:
+        return 0.0
+    h, m, s, ms = match.groups()
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+
+
+def parse_sbv(content: str) -> list[dict]:
+    """Parse Google Meet SBV format."""
+    segments = []
+    blocks = re.split(r"\n\n+", content.strip())
+
+    for block in blocks:
+        lines = block.strip().split("\n")
+        if len(lines) < 2:
+            continue
+
+        # First line: timestamp range
+        ts_match = re.match(
+            r"(\d+:\d+:\d+\.\d+),(\d+:\d+:\d+\.\d+)", lines[0]
+        )
+        if not ts_match:
+            continue
+
+        start = parse_sbv_timestamp(ts_match.group(1))
+        end = parse_sbv_timestamp(ts_match.group(2))
+        text = "\n".join(lines[1:]).strip()
+
+        # Check for speaker prefix like "Speaker Name: text"
+        speaker = None
+        speaker_match = re.match(r"^([^:]+):\s*(.+)$", text, re.DOTALL)
+        if speaker_match:
+            speaker = speaker_match.group(1).strip()
+            text = speaker_match.group(2).strip()
+
+        segments.append({
+            "start": start,
+            "end": end,
+            "text": text,
+            "speaker": speaker,
+            "words": [],
+        })
+
+    return segments
+
+
+def parse_vtt_timestamp(ts: str) -> float:
+    """Parse VTT timestamp (HH:MM:SS.mmm) to seconds."""
+    match = re.match(r"(\d+):(\d+):(\d+)\.(\d+)", ts.strip())
+    if not match:
+        # Try MM:SS.mmm format
+        match = re.match(r"(\d+):(\d+)\.(\d+)", ts.strip())
+        if match:
+            m, s, ms = match.groups()
+            return int(m) * 60 + int(s) + int(ms) / 1000
+        return 0.0
+    h, m, s, ms = match.groups()
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+
+
+def parse_vtt(content: str) -> list[dict]:
+    """Parse MS Teams VTT format with <v Name> speaker tags."""
+    segments = []
+    # Remove WEBVTT header and any NOTE blocks
+    content = re.sub(r"^WEBVTT.*?\n\n", "", content, flags=re.DOTALL)
+    content = re.sub(r"NOTE.*?\n\n", "", content, flags=re.DOTALL)
+
+    blocks = re.split(r"\n\n+", content.strip())
+
+    for block in blocks:
+        lines = block.strip().split("\n")
+        if not lines:
+            continue
+
+        # Find timestamp line
+        ts_line = None
+        text_lines = []
+        for line in lines:
+            ts_match = re.match(
+                r"(\d+:\d+:\d+\.\d+)\s*-->\s*(\d+:\d+:\d+\.\d+)", line
+            )
+            if not ts_match and re.match(
+                r"(\d+:\d+\.\d+)\s*-->\s*(\d+:\d+\.\d+)", line
+            ):
+                ts_match = re.match(
+                    r"(\d+:\d+\.\d+)\s*-->\s*(\d+:\d+\.\d+)", line
+                )
+            if ts_match:
+                ts_line = ts_match
+            elif ts_line is not None:
+                text_lines.append(line)
+
+        if not ts_line or not text_lines:
+            continue
+
+        start = parse_vtt_timestamp(ts_line.group(1))
+        end = parse_vtt_timestamp(ts_line.group(2))
+        text = "\n".join(text_lines).strip()
+
+        # Check for <v Name> speaker tags (MS Teams format)
+        speaker = None
+        v_match = re.match(r"<v\s+([^>]+)>(.*?)(?:</v>)?$", text, re.DOTALL)
+        if v_match:
+            speaker = v_match.group(1).strip()
+            text = v_match.group(2).strip()
+
+        segments.append({
+            "start": start,
+            "end": end,
+            "text": text,
+            "speaker": speaker,
+            "words": [],
+        })
+
+    return segments
+
+
+def parse_google_txt(content: str) -> list[dict]:
+    """Parse Google Meet .txt format with speaker headers like 'Name (H:MM:SS)'."""
+    segments = []
+    # Match lines like "Speaker Name (0:12:34)"
+    header_pattern = re.compile(r"^(.+?)\s*\((\d+:\d+:\d+)\)\s*$", re.MULTILINE)
+    headers = list(header_pattern.finditer(content))
+
+    for i, match in enumerate(headers):
+        speaker = match.group(1).strip()
+        ts_str = match.group(2)
+        parts = ts_str.split(":")
+        start = int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+
+        # Text is between this header and the next
+        text_start = match.end()
+        text_end = headers[i + 1].start() if i + 1 < len(headers) else len(content)
+        text = content[text_start:text_end].strip()
+
+        # End time = next segment's start, or start + 30s for last segment
+        end = (
+            int(headers[i + 1].group(2).split(":")[0]) * 3600
+            + int(headers[i + 1].group(2).split(":")[1]) * 60
+            + int(headers[i + 1].group(2).split(":")[2])
+            if i + 1 < len(headers)
+            else start + 30
+        )
+
+        if text:
+            segments.append({
+                "start": float(start),
+                "end": float(end),
+                "text": text,
+                "speaker": speaker,
+                "words": [],
+            })
+
+    return segments
+
+
+def parse_teams_docx(input_path: Path) -> list[dict]:
+    """Parse MS Teams .docx transcript."""
+    from docx import Document
+
+    doc = Document(str(input_path))
+    segments = []
+    current_speaker = None
+    current_start = 0.0
+    current_texts = []
+
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if not text:
+            continue
+
+        # Teams docx typically has speaker + timestamp lines followed by text
+        # Pattern: "Speaker Name  0:12:34"
+        header_match = re.match(r"^(.+?)\s{2,}(\d+:\d+:\d+)\s*$", text)
+        if header_match:
+            # Save previous segment
+            if current_texts:
+                segments.append({
+                    "start": current_start,
+                    "end": current_start + 30,  # placeholder until next segment
+                    "text": " ".join(current_texts),
+                    "speaker": current_speaker,
+                    "words": [],
+                })
+
+            current_speaker = header_match.group(1).strip()
+            ts_parts = header_match.group(2).split(":")
+            current_start = (
+                float(int(ts_parts[0]) * 3600 + int(ts_parts[1]) * 60 + int(ts_parts[2]))
+            )
+            current_texts = []
+        else:
+            current_texts.append(text)
+
+    # Save final segment
+    if current_texts:
+        segments.append({
+            "start": current_start,
+            "end": current_start + 30,
+            "text": " ".join(current_texts),
+            "speaker": current_speaker,
+            "words": [],
+        })
+
+    # Fix end times: each segment ends when the next begins
+    for i in range(len(segments) - 1):
+        segments[i]["end"] = segments[i + 1]["start"]
+
+    return segments
+
+
+def convert(input_path: Path, output_dir: Path, fmt: str) -> None:
+    """Convert external transcript to canonical format."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Detect format if auto
+    if fmt == "auto":
+        fmt = detect_format(input_path)
+
+    print(f"Detected format: {fmt}")
+
+    # Parse based on format
+    if fmt == "teams_docx":
+        segments = parse_teams_docx(input_path)
+    else:
+        content = input_path.read_text(encoding="utf-8", errors="replace")
+        if fmt == "sbv":
+            segments = parse_sbv(content)
+        elif fmt == "vtt":
+            segments = parse_vtt(content)
+        elif fmt == "google_txt":
+            segments = parse_google_txt(content)
+        else:
+            print(f"Unknown format: {fmt}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"Parsed {len(segments)} segments")
+
+    has_speakers = any(seg["speaker"] for seg in segments)
+    has_timestamps = any(seg["start"] > 0 or seg["end"] > 0 for seg in segments)
+
+    # Write canonical transcript.json
+    transcript = {"segments": segments}
+    transcript_path = output_dir / "transcript.json"
+    transcript_path.write_text(json.dumps(transcript, indent=2, ensure_ascii=False))
+    print(f"Transcript saved to {transcript_path}")
+
+    # Write metadata
+    format_labels = {
+        "sbv": "google_meet_sbv",
+        "vtt": "ms_teams_vtt",
+        "google_txt": "google_meet_txt",
+        "teams_docx": "ms_teams_docx",
+    }
+    meta = {
+        "source": format_labels.get(fmt, fmt),
+        "has_timestamps": has_timestamps,
+        "has_speakers": has_speakers,
+        "original_file": input_path.name,
+        "segment_count": len(segments),
+    }
+    meta_path = output_dir / "external_transcript_meta.json"
+    meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False))
+    print(f"Metadata saved to {meta_path}")
+
+    # Copy original file
+    dest_ext = input_path.suffix
+    original_copy = output_dir / f"external_transcript_original{dest_ext}"
+    shutil.copy2(input_path, original_copy)
+    print(f"Original copied to {original_copy}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert external transcripts to canonical JSON format"
+    )
+    parser.add_argument("--input", required=True, help="Path to transcript file")
+    parser.add_argument("--output-dir", required=True, help="Output directory")
+    parser.add_argument(
+        "--format",
+        default="auto",
+        choices=["auto", "sbv", "vtt", "google_txt", "teams_docx"],
+        help="Transcript format (default: auto-detect)",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    if not input_path.exists():
+        print(f"Input file not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+
+    convert(input_path, output_dir, args.format)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/analyze-video/scripts/transcribe.py
+++ b/.claude/skills/analyze-video/scripts/transcribe.py
@@ -181,6 +181,12 @@ def transcribe_single(audio_path: Path, output_dir: Path, model: str) -> None:
         target_srt = output_dir / "transcript.srt"
         whisper_srt.rename(target_srt)
 
+    # Clean up extra whisper output formats
+    for ext in (".tsv", ".txt", ".vtt"):
+        extra = output_dir / f"{stem}{ext}"
+        if extra.exists():
+            extra.unlink()
+
 
 def transcribe_chunked(
     audio_path: Path, output_dir: Path, model: str, chunk_duration: int = 1800

--- a/.claude/skills/analyze-video/scripts/transcribe.py
+++ b/.claude/skills/analyze-video/scripts/transcribe.py
@@ -64,20 +64,43 @@ def split_audio(audio_path: Path, chunk_duration: int, temp_dir: Path) -> list[P
     return chunks
 
 
-def run_whisper(audio_path: Path, output_dir: Path, model: str) -> None:
-    """Run whisper on an audio file."""
-    result = subprocess.run(
-        [
-            "whisper",
-            str(audio_path),
-            "--model", model,
-            "--word_timestamps", "True",
-            "--output_format", "all",
-            "--output_dir", str(output_dir),
+def detect_language(audio_path: Path, model_name: str = "base") -> dict:
+    """Detect language from the first 30 seconds of audio using Whisper's Python API."""
+    import whisper
+
+    model = whisper.load_model(model_name)
+    audio = whisper.load_audio(str(audio_path))
+    audio = audio[: 30 * 16000]  # first 30 seconds
+    audio = whisper.pad_or_trim(audio)
+    mel = whisper.log_mel_spectrogram(audio).to(model.device)
+    _, probs = model.detect_language(mel)
+    sorted_langs = sorted(probs.items(), key=lambda x: x[1], reverse=True)
+    top = sorted_langs[0]
+    return {
+        "language": top[0],
+        "confidence": top[1],
+        "alternatives": [
+            {"language": lang, "confidence": prob}
+            for lang, prob in sorted_langs[1:6]
         ],
-        capture_output=True,
-        text=True,
-    )
+    }
+
+
+def run_whisper(
+    audio_path: Path, output_dir: Path, model: str, language: str | None = None
+) -> None:
+    """Run whisper on an audio file."""
+    cmd = [
+        "whisper",
+        str(audio_path),
+        "--model", model,
+        "--word_timestamps", "True",
+        "--output_format", "all",
+        "--output_dir", str(output_dir),
+    ]
+    if language:
+        cmd.extend(["--language", language])
+    result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Whisper failed: {result.stderr}", file=sys.stderr)
         sys.exit(1)
@@ -164,9 +187,11 @@ def offset_json_segments(segments: list[dict], offset_seconds: float) -> list[di
     return result
 
 
-def transcribe_single(audio_path: Path, output_dir: Path, model: str) -> None:
+def transcribe_single(
+    audio_path: Path, output_dir: Path, model: str, language: str | None = None
+) -> None:
     """Transcribe a single audio file directly."""
-    run_whisper(audio_path, output_dir, model)
+    run_whisper(audio_path, output_dir, model, language=language)
 
     # Whisper outputs files named after the input audio stem
     stem = audio_path.stem
@@ -189,7 +214,11 @@ def transcribe_single(audio_path: Path, output_dir: Path, model: str) -> None:
 
 
 def transcribe_chunked(
-    audio_path: Path, output_dir: Path, model: str, chunk_duration: int = 1800
+    audio_path: Path,
+    output_dir: Path,
+    model: str,
+    chunk_duration: int = 1800,
+    language: str | None = None,
 ) -> None:
     """Transcribe long audio by splitting into chunks and merging."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -207,7 +236,7 @@ def transcribe_chunked(
 
             chunk_out = tmp_dir / f"chunk_{i:04d}_out"
             chunk_out.mkdir(exist_ok=True)
-            run_whisper(chunk_path, chunk_out, model)
+            run_whisper(chunk_path, chunk_out, model, language=language)
 
             # Read chunk SRT
             chunk_srt_path = chunk_out / f"{chunk_path.stem}.srt"
@@ -237,22 +266,41 @@ def transcribe_chunked(
 def main():
     parser = argparse.ArgumentParser(description="Transcribe audio using Whisper")
     parser.add_argument("--input", required=True, help="Path to input audio file")
-    parser.add_argument("--output-dir", required=True, help="Output directory")
+    parser.add_argument("--output-dir", help="Output directory (required unless --detect-language)")
     parser.add_argument(
         "--model",
         default="base",
         choices=["base", "medium", "large"],
         help="Whisper model size (default: base)",
     )
+    parser.add_argument(
+        "--language",
+        help="Language code to pass to Whisper (e.g. en, es, pt), skipping auto-detection",
+    )
+    parser.add_argument(
+        "--detect-language",
+        action="store_true",
+        help="Detect language from audio and output JSON to stdout (always uses base model)",
+    )
     args = parser.parse_args()
 
     audio_path = Path(args.input).resolve()
-    output_dir = Path(args.output_dir).resolve()
 
     if not audio_path.exists():
         print(f"Input file not found: {audio_path}", file=sys.stderr)
         sys.exit(1)
 
+    # Language detection mode
+    if args.detect_language:
+        result = detect_language(audio_path, model_name="base")
+        print(json.dumps(result, indent=2))
+        return
+
+    if not args.output_dir:
+        print("--output-dir is required for transcription", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = Path(args.output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     duration = get_audio_duration(audio_path)
@@ -260,9 +308,9 @@ def main():
 
     # Use chunking for files over 30 minutes
     if duration > 1800:
-        transcribe_chunked(audio_path, output_dir, args.model)
+        transcribe_chunked(audio_path, output_dir, args.model, language=args.language)
     else:
-        transcribe_single(audio_path, output_dir, args.model)
+        transcribe_single(audio_path, output_dir, args.model, language=args.language)
 
     print("Transcription complete.")
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .video2pr/
 test_videos_dont_commit/
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,7 @@ Use the `/analyze-video <path>` skill to process a video recording.
 - `environment.yml` — Conda environment definition
 - `.claude/skills/analyze-video/` — Skill definition and scripts
 - `.video2pr/` — Runtime output directory (per-video, gitignored)
+
+## Git Workflow
+
+Always create a feature branch from `main`, open a PR, then merge to `main`. Never commit directly to `main`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# video2PR
+
+Converts meeting video recordings into structured context for coding assistants. Extracts audio, transcribes with timestamps, detects language, and produces a structured summary with topics, action items, decisions, and visual references.
+
+## Features
+
+- **Audio extraction** — Extracts 16kHz mono WAV from video files (mp4, mkv, avi, mov, webm)
+- **Language detection** — Identifies spoken language with confidence scoring before transcription
+- **Whisper transcription** — Word-level timestamps with automatic chunking for long recordings
+- **External transcript support** — Imports Google Meet (SBV, TXT) and MS Teams (VTT, DOCX) transcripts with speaker attribution
+- **Structured summary** — Topics, action items, decisions, feature requests, and visual references with timestamps
+- **On-demand frame extraction** — Pull specific video frames when visual context is needed
+
+## Setup
+
+```bash
+conda env create -f environment.yml
+conda activate video2pr
+```
+
+## Usage
+
+Use the Claude Code skill to process a recording:
+
+```
+/analyze-video path/to/meeting.mp4
+```
+
+The skill will:
+1. Check dependencies
+2. Validate the video and search for external transcripts in the same directory
+3. Extract audio and detect language (asks for confirmation if confidence < 80%)
+4. Transcribe using Whisper or convert the external transcript
+5. Analyze and generate a structured summary
+
+Output is saved to `.video2pr/<video-name>/`.
+
+### External Transcripts
+
+If a transcript file is found alongside the video (matching basename with `.sbv`, `.vtt`, `.txt`, or `.docx` extension), it will be used automatically. External transcripts preserve speaker attribution that Whisper alone cannot provide.
+
+### Standalone Scripts
+
+```bash
+# Detect language
+conda run -n video2pr python .claude/skills/analyze-video/scripts/transcribe.py \
+  --input audio.wav --detect-language
+
+# Transcribe with explicit language
+conda run -n video2pr python .claude/skills/analyze-video/scripts/transcribe.py \
+  --input audio.wav --output-dir out --model base --language en
+
+# Convert an external transcript
+conda run -n video2pr python .claude/skills/analyze-video/scripts/convert_transcript.py \
+  --input meeting.vtt --output-dir out
+```
+
+## Output Files
+
+| File | Description |
+|------|-------------|
+| `audio.wav` | 16kHz mono audio |
+| `metadata.json` | ffprobe video metadata |
+| `transcript.json` | Segments with timestamps, text, and optional speaker/word data |
+| `transcript.srt` | SRT subtitles (Whisper-generated only) |
+| `summary.md` | Structured meeting analysis |
+| `external_transcript_meta.json` | Source format info (external transcript only) |
+| `external_transcript_original.*` | Copy of original transcript (external only) |
+
+## Project Structure
+
+```
+video2PR/
+├── CLAUDE.md                          # Project instructions for Claude Code
+├── environment.yml                    # Conda environment definition
+├── .claude/skills/analyze-video/
+│   ├── SKILL.md                       # Skill phases and orchestration
+│   └── scripts/
+│       ├── check_deps.py              # Dependency checker
+│       ├── extract_audio.py           # Audio extraction + metadata
+│       ├── extract_frame.py           # On-demand frame extraction
+│       ├── convert_transcript.py      # External transcript parser
+│       └── transcribe.py             # Whisper transcription + language detection
+└── .video2pr/                         # Runtime output (gitignored)
+```

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - pip
   - pip:
       - openai-whisper
+      - python-docx


### PR DESCRIPTION
## Summary
- Add `--language` and `--detect-language` flags to `transcribe.py` for explicit language control and confidence-scored detection via Whisper's Python API
- Create `convert_transcript.py` to parse Google Meet (SBV, TXT) and MS Teams (VTT, DOCX) transcripts into canonical JSON with speaker attribution
- Restructure SKILL.md phases to support external transcripts, language confirmation (when confidence < 80%), and speaker enrichment
- Add `python-docx` dependency for Teams .docx support
- Add project README.md and document branch-based PR workflow in CLAUDE.md

## Test plan
- [ ] `conda run -n video2pr python scripts/transcribe.py --input audio.wav --detect-language` → JSON with language + confidence
- [ ] `conda run -n video2pr python scripts/transcribe.py --input audio.wav --output-dir out --model base --language en` → transcript using English
- [ ] `conda run -n video2pr python scripts/convert_transcript.py --input sample.vtt --output-dir out` → canonical transcript.json with speakers
- [ ] Full pipeline with test video (no external transcript) → language detection step runs
- [ ] Full pipeline with external transcript alongside video → uses external transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)