### PR TITLE
Rewrite README with getting-started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,46 @@
 # video2PR
 
-Converts meeting video recordings into structured context for coding assistants. Extracts audio, transcribes with timestamps, detects language, and produces a structured summary with topics, action items, decisions, and visual references.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that converts meeting video recordings into structured context for coding assistants — transcripts with timestamps, speaker attribution, action items, and decisions.
 
-## Features
+## Getting Started
 
-- **Audio extraction** — Extracts 16kHz mono WAV from video files (mp4, mkv, avi, mov, webm)
-- **Language detection** — Identifies spoken language with confidence scoring before transcription
-- **Whisper transcription** — Word-level timestamps with automatic chunking for long recordings
-- **External transcript support** — Imports Google Meet (SBV, TXT) and MS Teams (VTT, DOCX) transcripts with speaker attribution
-- **Structured summary** — Topics, action items, decisions, feature requests, and visual references with timestamps
-- **On-demand frame extraction** — Pull specific video frames when visual context is needed
-
-## Setup
+### 1. Install dependencies
 
 ```bash
 conda env create -f environment.yml
 conda activate video2pr
 ```
 
-## Usage
+### 2. Install the skill
 
-Use the Claude Code skill to process a recording:
+Copy `.claude/skills/analyze-video/` into your project's `.claude/skills/` directory:
+
+```bash
+cp -r .claude/skills/analyze-video /path/to/your-project/.claude/skills/
+```
+
+Also copy `environment.yml` if your project doesn't already have one.
+
+### 3. Run it
+
+In Claude Code, from your project directory:
 
 ```
 /analyze-video path/to/meeting.mp4
 ```
 
-The skill will:
-1. Check dependencies
-2. Validate the video and search for external transcripts in the same directory
-3. Extract audio and detect language (asks for confirmation if confidence < 80%)
-4. Transcribe using Whisper or convert the external transcript
-5. Analyze and generate a structured summary
+Output goes to `.video2pr/<video-name>/` (add `.video2pr/` to your `.gitignore`).
 
-Output is saved to `.video2pr/<video-name>/`.
+## What It Does
 
-### External Transcripts
+1. Extracts audio from video (mp4, mkv, avi, mov, webm)
+2. Detects spoken language with confidence scoring — asks for confirmation if < 80%
+3. Transcribes via Whisper with word-level timestamps, or imports an external transcript (Google Meet SBV/TXT, MS Teams VTT/DOCX) with speaker attribution
+4. Produces `summary.md` with topics, action items, decisions, and visual reference commands
 
-If a transcript file is found alongside the video (matching basename with `.sbv`, `.vtt`, `.txt`, or `.docx` extension), it will be used automatically. External transcripts preserve speaker attribution that Whisper alone cannot provide.
+If a transcript file sits next to the video (same name, `.sbv`/`.vtt`/`.txt`/`.docx` extension), it's picked up automatically.
 
-### Standalone Scripts
+## Standalone Scripts
 
 ```bash
 # Detect language
@@ -61,25 +62,8 @@ conda run -n video2pr python .claude/skills/analyze-video/scripts/convert_transc
 |------|-------------|
 | `audio.wav` | 16kHz mono audio |
 | `metadata.json` | ffprobe video metadata |
-| `transcript.json` | Segments with timestamps, text, and optional speaker/word data |
+| `transcript.json` | Segments with timestamps, text, optional speaker/word data |
 | `transcript.srt` | SRT subtitles (Whisper-generated only) |
 | `summary.md` | Structured meeting analysis |
 | `external_transcript_meta.json` | Source format info (external transcript only) |
 | `external_transcript_original.*` | Copy of original transcript (external only) |
-
-## Project Structure
-
-```
-video2PR/
-├── CLAUDE.md                          # Project instructions for Claude Code
-├── environment.yml                    # Conda environment definition
-├── .claude/skills/analyze-video/
-│   ├── SKILL.md                       # Skill phases and orchestration
-│   └── scripts/
-│       ├── check_deps.py              # Dependency checker
-│       ├── extract_audio.py           # Audio extraction + metadata
-│       ├── extract_frame.py           # On-demand frame extraction
-│       ├── convert_transcript.py      # External transcript parser
-│       └── transcribe.py             # Whisper transcription + language detection
-└── .video2pr/                         # Runtime output (gitignored)
-```


### PR DESCRIPTION
## Summary
- Lead with a 3-step getting-started: install deps, copy the skill into your project, run it
- Remove project structure tree and feature bullet list — replaced with a concise "What It Does" section
- Keep standalone scripts and output files table for reference

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)