### PR TITLE
Fix analyze-video skill to consistently use conda env

### DIFF
--- a/.claude/skills/analyze-video/SKILL.md
+++ b/.claude/skills/analyze-video/SKILL.md
@@ -36,7 +36,7 @@ The user provides a video file path as the argument. Verify:
 3. Get duration via ffprobe:
 
 ```bash
-ffprobe -v quiet -print_format json -show_format "<video-path>" | python -c "import sys,json; d=float(json.load(sys.stdin)['format']['duration']); print(f'Duration: {d:.0f}s ({d/60:.1f} min)')"
+conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/get_duration.py --input "<video-path>"
 ```
 
 Set up the output directory:
@@ -96,11 +96,11 @@ If no external transcript → continue to Phase 3c.
    conda run -n video2pr python ${CLAUDE_SKILL_DIR}/scripts/transcribe.py \
      --input ".video2pr/<video-basename>/audio.wav" \
      --output-dir ".video2pr/<video-basename>" \
-     --model base \
+     --model small \
      --language <confirmed-language-code>
    ```
 
-For higher accuracy (longer processing), use `--model medium` or `--model large`.
+The default model is `small` (good balance of speed and accuracy). For faster but less accurate results use `--model base`; for higher accuracy (longer processing) use `--model medium` or `--model large`.
 
 ### Phase 3d: Speaker Enrichment (conditional)
 

--- a/.claude/skills/analyze-video/scripts/check_deps.py
+++ b/.claude/skills/analyze-video/scripts/check_deps.py
@@ -1,78 +1,112 @@
 #!/usr/bin/env python3
-"""Pre-flight dependency check for video2pr pipeline."""
+"""Pre-flight dependency check for video2pr pipeline.
 
-import shutil
+Checks that the video2pr conda environment exists and that all required
+CLI tools and Python packages are available *inside* that environment.
+This script itself runs from system Python — no conda activation needed.
+"""
+
+import json
 import subprocess
 import sys
+from pathlib import Path
 
 
-def check_command(name):
-    """Check if a command is available on PATH."""
-    return shutil.which(name) is not None
+ENV_NAME = "video2pr"
+CLI_TOOLS = ["ffmpeg", "ffprobe", "whisper"]
+PYTHON_IMPORTS = {"python-docx": "docx"}
 
 
-def check_conda_env(env_name):
-    """Check if a conda environment exists."""
+def conda_available():
+    """Check if conda is on the system PATH and working."""
     try:
         result = subprocess.run(
-            ["conda", "env", "list", "--json"],
+            ["conda", "--version"],
             capture_output=True,
             text=True,
         )
-        if result.returncode == 0:
-            import json
-
-            envs = json.loads(result.stdout).get("envs", [])
-            return any(e.endswith(f"/{env_name}") for e in envs)
+        return result.returncode == 0
     except FileNotFoundError:
-        pass
-    return False
-
-
-def check_python_import(module_name):
-    """Check if a Python module can be imported."""
-    try:
-        __import__(module_name)
-        return True
-    except ImportError:
         return False
 
 
+def env_exists(env_name):
+    """Check if a conda environment exists."""
+    result = subprocess.run(
+        ["conda", "env", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    envs = json.loads(result.stdout).get("envs", [])
+    return any(Path(e).name == env_name for e in envs)
+
+
+def check_deps_in_env():
+    """Check all CLI tools and Python imports in a single conda run call.
+
+    Returns (cli_results, import_results) where each is a dict of name -> bool.
+    """
+    # Build a single Python script that checks everything
+    checks = []
+    for tool in CLI_TOOLS:
+        checks.append(f"import shutil; results[{tool!r}] = shutil.which({tool!r}) is not None")
+    for name, module in PYTHON_IMPORTS.items():
+        checks.append(
+            f"try:\n    __import__({module!r}); results[{name!r}] = True\n"
+            f"except ImportError:\n    results[{name!r}] = False"
+        )
+
+    script = "import shutil, json\nresults = {}\n" + "\n".join(checks) + "\nprint(json.dumps(results))"
+
+    result = subprocess.run(
+        ["conda", "run", "-n", ENV_NAME, "python", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Fallback: report everything as missing
+        all_names = CLI_TOOLS + list(PYTHON_IMPORTS.keys())
+        return {name: False for name in all_names}
+
+    return json.loads(result.stdout)
+
+
 def main():
-    deps = {
-        "ffmpeg": check_command("ffmpeg"),
-        "ffprobe": check_command("ffprobe"),
-        "whisper": check_command("whisper"),
-    }
-    pip_deps = {
-        "python-docx": check_python_import("docx"),
-    }
-    conda_ok = check_conda_env("video2pr")
-
     print("=== video2pr dependency check ===")
-    for name, found in deps.items():
+
+    if not conda_available():
+        print("  conda: MISSING")
+        print("\nMISSING: conda")
+        print("\nInstall conda/miniconda first, then run:")
+        print("  conda env create -f environment.yml")
+        sys.exit(1)
+    print("  conda: OK")
+
+    if not env_exists(ENV_NAME):
+        print(f"  conda env ({ENV_NAME}): MISSING")
+        print(f"\nMISSING: conda env ({ENV_NAME})")
+        print("\nTo set up the environment:")
+        print("  conda env create -f environment.yml")
+        sys.exit(1)
+    print(f"  conda env ({ENV_NAME}): OK")
+
+    results = check_deps_in_env()
+    missing = []
+    for name, found in results.items():
         status = "OK" if found else "MISSING"
         print(f"  {name}: {status}")
-    for name, found in pip_deps.items():
-        status = "OK" if found else "MISSING"
-        print(f"  {name}: {status}")
-
-    print(f"  conda env (video2pr): {'OK' if conda_ok else 'MISSING'}")
-
-    missing = [name for name, found in deps.items() if not found]
-    missing.extend(name for name, found in pip_deps.items() if not found)
-    if not conda_ok:
-        missing.append("conda env (video2pr)")
+        if not found:
+            missing.append(name)
 
     if missing:
         print(f"\nMISSING: {', '.join(missing)}")
-        print("\nTo set up the environment:")
-        print("  conda env create -f environment.yml")
-        print("  conda activate video2pr")
-    else:
-        print("\nAll dependencies found.")
+        print("\nTo fix, update the environment:")
+        print("  conda env update -f environment.yml")
+        sys.exit(1)
 
-    sys.exit(0)
+    print("\nAll dependencies found.")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/analyze-video/scripts/get_duration.py
+++ b/.claude/skills/analyze-video/scripts/get_duration.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Get video duration using ffprobe.
+
+Designed to run inside the video2pr conda env where ffprobe is available.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get video duration via ffprobe")
+    parser.add_argument("--input", required=True, help="Path to input video file")
+    args = parser.parse_args()
+
+    input_path = Path(args.input).resolve()
+    if not input_path.exists():
+        print(f"Input file not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v", "quiet",
+            "-print_format", "json",
+            "-show_format",
+            str(input_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"ffprobe failed: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(result.stdout)
+    try:
+        duration = float(data["format"]["duration"])
+    except (KeyError, ValueError) as e:
+        print(f"Could not parse duration from ffprobe output: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Duration: {duration:.0f}s ({duration / 60:.1f} min)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/analyze-video/scripts/transcribe.py
+++ b/.claude/skills/analyze-video/scripts/transcribe.py
@@ -269,9 +269,9 @@ def main():
     parser.add_argument("--output-dir", help="Output directory (required unless --detect-language)")
     parser.add_argument(
         "--model",
-        default="base",
-        choices=["base", "medium", "large"],
-        help="Whisper model size (default: base)",
+        default="small",
+        choices=["base", "small", "medium", "large"],
+        help="Whisper model size (default: small)",
     )
     parser.add_argument(
         "--language",


### PR DESCRIPTION
## Summary
- Rewrote `check_deps.py` to verify CLI tools and Python imports *inside* the conda env via a single batched `conda run` call (faster, no false negatives)
- Added `get_duration.py` script to replace the fragile inline `ffprobe | python` pipe in SKILL.md
- Changed default Whisper model from `base` to `small` with docs for all options
- Fixed `sys.exit(0)` on missing deps (now exits non-zero), fragile env-name suffix matching, and other quality issues from code review

## Test plan
- [ ] Run `python .claude/skills/analyze-video/scripts/check_deps.py` — all deps OK
- [ ] Run `conda run -n video2pr python .claude/skills/analyze-video/scripts/get_duration.py --input <video>` — prints duration
- [ ] Run `/analyze-video` on a test video — full pipeline completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)