### PR TITLE
Show Whisper transcription progress in real time

### DIFF
--- a/.claude/skills/analyze-video/scripts/transcribe.py
+++ b/.claude/skills/analyze-video/scripts/transcribe.py
@@ -100,11 +100,10 @@ def run_whisper(
     ]
     if language:
         cmd.extend(["--language", language])
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd)
     if result.returncode != 0:
-        print(f"Whisper failed: {result.stderr}", file=sys.stderr)
+        print("Whisper failed", file=sys.stderr)
         sys.exit(1)
-    print(result.stdout)
 
 
 def parse_srt_timestamp(ts: str) -> float:


### PR DESCRIPTION
## Summary
- Stop capturing Whisper CLI stdout/stderr so per-segment progress prints as it runs
- Previously all output was swallowed by `capture_output=True` and only printed after completion

## Test plan
- [ ] Run transcription on a test video and verify per-segment progress appears in real time
- [ ] Verify output is readable (no text overflow or excessive noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)