### PR TITLE
Remove conda activate step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ All platforms share the same Python scripts in `scripts/` — only the SKILL.md 
 
 ```bash
 conda env create -f environment.yml
-conda activate video2pr
 ```
+
+The agent runs commands via `conda run -n video2pr`, so `conda activate` is not needed.
 
 ### 2. Install the skill
 


### PR DESCRIPTION
## Summary
- Removed `conda activate video2pr` from install instructions since the agent uses `conda run -n video2pr` directly
- Added clarifying note explaining why activation isn't needed

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)