### PR TITLE
Add codebase scope rules to SKILL.md files

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -17,6 +17,11 @@ allowed-tools: shell read_file apply_patch list_dir grep_files
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
+**Important — scope rules:**
+- The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The only new directory created is `.video2pr/` inside the repo root for output files.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:
@@ -149,7 +154,7 @@ For each item, record:
 
 ### Step 5b: Scan Codebase
 
-For each actionable item, search the codebase using file listing and content search tools. Classify each item:
+For each actionable item, search the codebase **within the repository root** using file listing and content search tools — not the video file's directory. Classify each item:
 
 - **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
 - **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -18,6 +18,11 @@ allowed-tools:
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
+**Important — scope rules:**
+- The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The only new directory created is `.video2pr/` inside the repo root for output files.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:
@@ -150,7 +155,7 @@ For each item, record:
 
 ### Step 5b: Scan Codebase
 
-For each actionable item, use Glob and Read to search the codebase. Classify each item:
+For each actionable item, use Glob and Read to search the codebase **within the repository root** — not the video file's directory. Classify each item:
 
 - **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
 - **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -17,6 +17,11 @@ allowed-tools: Bash Read Write Glob
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
+**Important — scope rules:**
+- The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The only new directory created is `.video2pr/` inside the repo root for output files.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:
@@ -149,7 +154,7 @@ For each item, record:
 
 ### Step 5b: Scan Codebase
 
-For each actionable item, search the codebase using file listing and content search tools. Classify each item:
+For each actionable item, search the codebase **within the repository root** using file listing and content search tools — not the video file's directory. Classify each item:
 
 - **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
 - **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.


### PR DESCRIPTION
## Summary
- Adds explicit scope rules after the opening line in all three SKILL.md files (Claude Code, Codex, Copilot), clarifying that "codebase" means the repository root — not the video file's directory
- Reinforces scope in Step 5b (Scan Codebase) instructions to prevent the agent from scanning outside the repo

## Test plan
- [ ] Run `/video2pr` with a video located outside the repo and verify the agent does not scan the video's parent directory
- [ ] Confirm codebase analysis stays within the repository root

🤖 Generated with [Claude Code](https://claude.com/claude-code)