### PR TITLE
Add install script and self-contained skill folders

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -22,6 +22,17 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
 
+## Phase 0: Check for Updates
+
+Run the update checker:
+
+```bash
+conda run -n video2pr python scripts/check_update.py
+```
+
+- If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
+- If output contains `UPDATE_AVAILABLE`: tell the user: "A video2pr update is available. To update, run: `conda run -n video2pr python scripts/check_update.py --apply`". Then continue to Phase 1 — do NOT auto-update.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -23,6 +23,17 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
 
+## Phase 0: Check for Updates
+
+Run the update checker:
+
+```bash
+conda run -n video2pr python scripts/check_update.py
+```
+
+- If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
+- If output contains `UPDATE_AVAILABLE`: tell the user: "A video2pr update is available. To update, run: `conda run -n video2pr python scripts/check_update.py --apply`". Then continue to Phase 1 — do NOT auto-update.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -22,6 +22,17 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
 
+## Phase 0: Check for Updates
+
+Run the update checker:
+
+```bash
+conda run -n video2pr python scripts/check_update.py
+```
+
+- If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
+- If output contains `UPDATE_AVAILABLE`: tell the user: "A video2pr update is available. To update, run: `conda run -n video2pr python scripts/check_update.py --apply`". Then continue to Phase 1 — do NOT auto-update.
+
 ## Phase 1: Dependency Check
 
 Run the dependency checker:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Use the `/video2pr <path>` skill to process a video recording.
 ## Project Structure
 
 - `environment.yml` — Conda environment definition
+- `install_video2pr.py` — Installer script (copies self-contained skill folders to target projects)
 - `scripts/` — Platform-neutral Python scripts (audio extraction, transcription, etc.)
 - `.claude/skills/video2pr/` — Claude Code skill definition (SKILL.md only)
 - `.agents/skills/video2pr/` — Codex CLI skill definition

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ video2PR works with multiple AI coding assistants:
 | [OpenAI Codex CLI](https://github.com/openai/codex) | `.agents/skills/video2pr/` | Full support |
 | [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli) | `.github/skills/video2pr/` | Full support |
 
-All platforms share the same Python scripts in `scripts/` — only the SKILL.md frontmatter differs.
+Each skill folder is fully self-contained — SKILL.md, scripts, and environment.yml are all included.
 
 ## Getting Started
 
@@ -26,11 +26,32 @@ The agent runs commands via `conda run -n video2pr`, so `conda activate` is not 
 
 ### 2. Install the skill
 
-Copy the `scripts/` directory and the skill definition for your platform into your project:
+```bash
+# Install to your project (all assistants)
+python /path/to/video2PR/install_video2pr.py /path/to/your-project
+
+# Install for specific assistants only
+python /path/to/video2PR/install_video2pr.py /path/to/your-project --assistants claude-code
+
+# Preview what will be installed
+python /path/to/video2PR/install_video2pr.py /path/to/your-project --dry-run
+```
+
+Each skill folder is fully self-contained — scripts and environment.yml are copied alongside the SKILL.md. No files are placed outside the skill folder.
+
+### Updating
+
+The skill checks for updates on each run and notifies you if a newer version is available. To apply:
 
 ```bash
-# Scripts (required for all platforms)
-cp -r scripts /path/to/your-project/scripts
+conda run -n video2pr python .claude/skills/video2pr/scripts/check_update.py --apply
+```
+
+<details>
+<summary>Manual installation</summary>
+
+```bash
+# Copy the skill folder for your platform into your project:
 
 # Claude Code
 cp -r .claude/skills/video2pr /path/to/your-project/.claude/skills/
@@ -44,7 +65,7 @@ mkdir -p /path/to/your-project/.github/agents
 cp .github/agents/video2pr.agent.md /path/to/your-project/.github/agents/
 ```
 
-Also copy `environment.yml` if your project doesn't already have one.
+</details>
 
 ### 3. Run it
 

--- a/install_video2pr.py
+++ b/install_video2pr.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Install video2pr skill into a target project directory.
+
+Each skill folder is fully self-contained: SKILL.md + scripts + environment.yml.
+No files are placed at the target project root (except .github/agents/ for Copilot).
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Source repo root (where this script lives)
+REPO_ROOT = Path(__file__).resolve().parent
+
+SCRIPT_NAMES = [
+    "check_deps.py",
+    "check_update.py",
+    "convert_transcript.py",
+    "extract_audio.py",
+    "extract_frame.py",
+    "get_duration.py",
+    "transcribe.py",
+]
+
+ASSISTANTS = {
+    "claude-code": {
+        "skill_dir": ".claude/skills/video2pr",
+        "skill_md": ".claude/skills/video2pr/SKILL.md",
+        "extra_files": [],
+    },
+    "codex": {
+        "skill_dir": ".agents/skills/video2pr",
+        "skill_md": ".agents/skills/video2pr/SKILL.md",
+        "extra_files": [
+            # (source_relative, dest_relative_to_skill_dir)
+            (".agents/skills/video2pr/agents/openai.yaml", "agents/openai.yaml"),
+        ],
+    },
+    "copilot": {
+        "skill_dir": ".github/skills/video2pr",
+        "skill_md": ".github/skills/video2pr/SKILL.md",
+        "extra_files": [
+            # This one goes outside the skill dir — handled specially
+        ],
+        "root_files": [
+            (".github/agents/video2pr.agent.md", ".github/agents/video2pr.agent.md"),
+        ],
+    },
+}
+
+
+def rewrite_paths(content: str, skill_dir: str) -> str:
+    """Rewrite script and environment paths in SKILL.md to use the skill directory prefix."""
+    content = content.replace("scripts/", f"{skill_dir}/scripts/")
+    content = content.replace("environment.yml", f"{skill_dir}/environment.yml")
+    return content
+
+
+def check_source_files() -> list[str]:
+    """Verify all required source files exist. Returns list of errors."""
+    errors = []
+    for name in SCRIPT_NAMES:
+        if not (REPO_ROOT / "scripts" / name).exists():
+            errors.append(f"Missing script: scripts/{name}")
+    if not (REPO_ROOT / "environment.yml").exists():
+        errors.append("Missing: environment.yml")
+    for assistant, cfg in ASSISTANTS.items():
+        skill_md = REPO_ROOT / cfg["skill_md"]
+        if not skill_md.exists():
+            errors.append(f"Missing: {cfg['skill_md']}")
+    return errors
+
+
+def get_conflicts(target: Path, assistants: list[str]) -> list[str]:
+    """Check for existing skill folders at the target."""
+    conflicts = []
+    for name in assistants:
+        cfg = ASSISTANTS[name]
+        skill_path = target / cfg["skill_dir"]
+        if skill_path.exists():
+            conflicts.append(str(skill_path))
+    return conflicts
+
+
+def install_assistant(target: Path, name: str, dry_run: bool) -> list[str]:
+    """Install one assistant's skill folder. Returns list of installed paths."""
+    cfg = ASSISTANTS[name]
+    skill_dir = cfg["skill_dir"]
+    dest = target / skill_dir
+    installed = []
+
+    # Create scripts directory
+    scripts_dest = dest / "scripts"
+    if dry_run:
+        print(f"  mkdir -p {scripts_dest.relative_to(target)}")
+    else:
+        scripts_dest.mkdir(parents=True, exist_ok=True)
+
+    # Copy scripts
+    for script_name in SCRIPT_NAMES:
+        src = REPO_ROOT / "scripts" / script_name
+        dst = scripts_dest / script_name
+        if dry_run:
+            print(f"  copy scripts/{script_name} -> {dst.relative_to(target)}")
+        else:
+            shutil.copy2(src, dst)
+        installed.append(f"scripts/{script_name}")
+
+    # Copy environment.yml
+    src = REPO_ROOT / "environment.yml"
+    dst = dest / "environment.yml"
+    if dry_run:
+        print(f"  copy environment.yml -> {dst.relative_to(target)}")
+    else:
+        shutil.copy2(src, dst)
+    installed.append("environment.yml")
+
+    # Copy and rewrite SKILL.md
+    src = REPO_ROOT / cfg["skill_md"]
+    dst = dest / "SKILL.md"
+    content = src.read_text()
+    content = rewrite_paths(content, skill_dir)
+    if dry_run:
+        print(f"  copy+rewrite {cfg['skill_md']} -> {dst.relative_to(target)}")
+    else:
+        dst.write_text(content)
+    installed.append("SKILL.md")
+
+    # Copy extra files within skill dir (e.g., openai.yaml)
+    for src_rel, dst_rel in cfg.get("extra_files", []):
+        src = REPO_ROOT / src_rel
+        dst = dest / dst_rel
+        if dry_run:
+            print(f"  copy {src_rel} -> {dst.relative_to(target)}")
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+        installed.append(dst_rel)
+
+    # Copy root-level files (e.g., copilot agent.md)
+    for src_rel, dst_rel in cfg.get("root_files", []):
+        src = REPO_ROOT / src_rel
+        dst = target / dst_rel
+        if dry_run:
+            print(f"  copy {src_rel} -> {dst.relative_to(target)}")
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+        installed.append(dst_rel)
+
+    # Write install config
+    config = {
+        "repo": "douglas125/video2PR",
+        "branch": "main",
+        "skill_dir": skill_dir,
+        "installed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "assistants_installed": [name],
+    }
+    config_path = dest / ".video2pr_install.json"
+    if dry_run:
+        print(f"  write {config_path.relative_to(target)}")
+    else:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+            f.write("\n")
+    installed.append(".video2pr_install.json")
+
+    return installed
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Install video2pr skill into a target project",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python install_video2pr.py /path/to/project\n"
+            "  python install_video2pr.py /path/to/project --assistants claude-code\n"
+            "  python install_video2pr.py /path/to/project --dry-run\n"
+        ),
+    )
+    parser.add_argument("target_path", type=Path,
+                        help="Target project root directory")
+    parser.add_argument("--assistants", nargs="+",
+                        choices=["claude-code", "codex", "copilot"],
+                        default=["claude-code", "codex", "copilot"],
+                        help="Which assistants to install for (default: all)")
+    parser.add_argument("--force", action="store_true",
+                        help="Overwrite existing skill folders")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be installed without writing")
+    args = parser.parse_args()
+
+    target = args.target_path.resolve()
+
+    # Validate target
+    if not target.exists() or not target.is_dir():
+        print(f"Error: {target} does not exist or is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate source files
+    errors = check_source_files()
+    if errors:
+        print("Error: Source files missing. Are you running from the video2PR repo?",
+              file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Check for conflicts
+    if not args.force and not args.dry_run:
+        conflicts = get_conflicts(target, args.assistants)
+        if conflicts:
+            print("Error: Existing skill folders found (use --force to overwrite):",
+                  file=sys.stderr)
+            for c in conflicts:
+                print(f"  {c}", file=sys.stderr)
+            sys.exit(1)
+
+    # Remove existing skill folders if --force
+    if args.force and not args.dry_run:
+        for name in args.assistants:
+            cfg = ASSISTANTS[name]
+            skill_path = target / cfg["skill_dir"]
+            if skill_path.exists():
+                shutil.rmtree(skill_path)
+
+    # Install
+    if args.dry_run:
+        print(f"Dry run — would install to {target}\n")
+
+    summary_lines = []
+    for name in args.assistants:
+        cfg = ASSISTANTS[name]
+        if args.dry_run:
+            print(f"[{name}] -> {cfg['skill_dir']}/")
+        installed = install_assistant(target, name, args.dry_run)
+        if args.dry_run:
+            print()
+
+        # Build summary
+        script_count = sum(1 for i in installed if i.startswith("scripts/"))
+        extras = []
+        if any("openai.yaml" in i for i in installed):
+            extras.append("agents/openai.yaml")
+        parts = f"SKILL.md + environment.yml + {script_count} scripts"
+        if extras:
+            parts += " + " + " + ".join(extras)
+        label = f"{name}:".ljust(13)
+        summary_lines.append(f"  {label}{cfg['skill_dir']}/ ({parts})")
+
+        # Copilot root file
+        if name == "copilot":
+            summary_lines.append(
+                f"  {'':13}.github/agents/video2pr.agent.md"
+            )
+
+    if not args.dry_run:
+        # Determine which env path to show (use first assistant's)
+        first_cfg = ASSISTANTS[args.assistants[0]]
+        env_path = f"{first_cfg['skill_dir']}/environment.yml"
+
+        print(f"\nvideo2pr installed to {target}\n")
+        for line in summary_lines:
+            print(line)
+        print(f"\n  Next steps:")
+        print(f"    1. conda env create -f {env_path}")
+        print(f"    2. Use /video2pr <video-path> in your coding assistant")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_update.py
+++ b/scripts/check_update.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check for and apply video2pr updates from GitHub."""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+GITHUB_API = "https://api.github.com/repos/{repo}/commits"
+GITHUB_RAW = "https://raw.githubusercontent.com/{repo}/{branch}/{path}"
+
+SCRIPT_NAMES = [
+    "check_deps.py",
+    "check_update.py",
+    "convert_transcript.py",
+    "extract_audio.py",
+    "extract_frame.py",
+    "get_duration.py",
+    "transcribe.py",
+]
+
+# Map assistant key to the source SKILL.md path in the repo
+SKILL_MD_SOURCES = {
+    ".claude/skills/video2pr": ".claude/skills/video2pr/SKILL.md",
+    ".agents/skills/video2pr": ".agents/skills/video2pr/SKILL.md",
+    ".github/skills/video2pr": ".github/skills/video2pr/SKILL.md",
+}
+
+
+def load_config(script_dir: Path) -> dict:
+    """Load .video2pr_install.json from the skill directory (parent of scripts/)."""
+    config_path = script_dir.parent / ".video2pr_install.json"
+    if not config_path.exists():
+        print("CHECK_SKIPPED: No .video2pr_install.json found", file=sys.stderr)
+        sys.exit(0)
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def fetch_json(url: str) -> dict:
+    """Fetch JSON from a URL."""
+    req = urllib.request.Request(url, headers={"User-Agent": "video2pr-updater"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode())
+
+
+def fetch_text(url: str) -> str:
+    """Fetch text content from a URL."""
+    req = urllib.request.Request(url, headers={"User-Agent": "video2pr-updater"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return resp.read().decode()
+
+
+def check(config: dict) -> bool:
+    """Check if updates are available. Returns True if update available."""
+    repo = config["repo"]
+    branch = config.get("branch", "main")
+    installed_at = config["installed_at"]
+
+    url = GITHUB_API.format(repo=repo) + f"?path=scripts&sha={branch}&per_page=1"
+    commits = fetch_json(url)
+
+    if not commits:
+        print("UP_TO_DATE")
+        return False
+
+    latest_date = commits[0]["commit"]["committer"]["date"]
+    if latest_date <= installed_at:
+        print("UP_TO_DATE")
+        return False
+
+    print(f"UPDATE_AVAILABLE: New changes since {installed_at}. "
+          f"Run with --apply to update.")
+    return True
+
+
+def rewrite_paths(content: str, skill_dir: str) -> str:
+    """Rewrite script and environment paths in SKILL.md content."""
+    content = content.replace("scripts/", f"{skill_dir}/scripts/")
+    content = content.replace("environment.yml", f"{skill_dir}/environment.yml")
+    return content
+
+
+def apply_update(config: dict, script_dir: Path) -> None:
+    """Download and apply updates."""
+    repo = config["repo"]
+    branch = config.get("branch", "main")
+    skill_dir = config["skill_dir"]
+    base_dir = script_dir.parent  # the skill directory
+
+    updated = []
+
+    # Update scripts
+    for name in SCRIPT_NAMES:
+        url = GITHUB_RAW.format(repo=repo, branch=branch, path=f"scripts/{name}")
+        try:
+            content = fetch_text(url)
+            dest = script_dir / name
+            dest.write_text(content)
+            updated.append(f"scripts/{name}")
+        except urllib.error.HTTPError as e:
+            print(f"  Warning: could not download {name}: {e}", file=sys.stderr)
+
+    # Update environment.yml
+    url = GITHUB_RAW.format(repo=repo, branch=branch, path="environment.yml")
+    try:
+        content = fetch_text(url)
+        (base_dir / "environment.yml").write_text(content)
+        updated.append("environment.yml")
+    except urllib.error.HTTPError as e:
+        print(f"  Warning: could not download environment.yml: {e}", file=sys.stderr)
+
+    # Update SKILL.md with path rewriting
+    source_path = SKILL_MD_SOURCES.get(skill_dir)
+    if source_path:
+        url = GITHUB_RAW.format(repo=repo, branch=branch, path=source_path)
+        try:
+            content = fetch_text(url)
+            content = rewrite_paths(content, skill_dir)
+            (base_dir / "SKILL.md").write_text(content)
+            updated.append("SKILL.md")
+        except urllib.error.HTTPError as e:
+            print(f"  Warning: could not download SKILL.md: {e}", file=sys.stderr)
+
+    # Update installed_at in config
+    config["installed_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    config_path = base_dir / ".video2pr_install.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    if updated:
+        print(f"UPDATED: {', '.join(updated)}")
+    else:
+        print("No files were updated.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for video2pr updates")
+    parser.add_argument("--apply", action="store_true",
+                        help="Download and apply available updates")
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    config = load_config(script_dir)
+
+    try:
+        if args.apply:
+            apply_update(config, script_dir)
+        else:
+            check(config)
+    except (urllib.error.URLError, OSError) as e:
+        print(f"CHECK_SKIPPED: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `install_video2pr.py` installer that copies self-contained skill folders (SKILL.md + scripts + environment.yml) to target projects with automatic path rewriting
- Add `scripts/check_update.py` that checks GitHub for newer versions and can apply updates in-place
- Add Phase 0 (update check) to all three SKILL.md files
- Update README.md with installer instructions and update docs
- Update CLAUDE.md project structure

## Test plan
- [x] `--dry-run` lists correct files for all 3 assistants
- [x] `--assistants claude-code` installs 7 scripts + env + SKILL.md + config
- [x] Path rewriting works (e.g. `scripts/` → `.claude/skills/video2pr/scripts/`)
- [x] Collision detection rejects without `--force`
- [x] `--force` overwrites successfully
- [x] Nonexistent target errors properly
- [x] Update checker returns `UP_TO_DATE` against GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)