### PR TITLE
Add pytest test suite (52 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .video2pr/
 test_videos_dont_commit/
 .DS_Store
+__pycache__/
+*.pyc

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pip:
       - openai-whisper
       - python-docx
+      - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,86 @@
+"""Shared fixtures for video2pr tests."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_script(name: str):
+    """Import a script by file path, avoiding sys.path pollution."""
+    if "/" in name:
+        script_path = REPO_ROOT / name
+    else:
+        script_path = REPO_ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(
+        name.replace("/", ".").removesuffix(".py"), script_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Temporarily add to sys.modules so relative imports work
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_install_mod = import_script("./install_video2pr.py")
+SCRIPT_NAMES = _install_mod.SCRIPT_NAMES
+
+SKILL_MD_CONTENT = """\
+---
+name: video2pr
+---
+
+Run `python scripts/check_deps.py` first.
+Install with `conda env create -f environment.yml`.
+"""
+
+
+@pytest.fixture(scope="session")
+def fake_repo(tmp_path_factory):
+    """Create a minimal source repo in a temp dir."""
+    root = tmp_path_factory.mktemp("fakerepo")
+
+    # scripts/ with stubs
+    scripts_dir = root / "scripts"
+    scripts_dir.mkdir()
+    for name in SCRIPT_NAMES:
+        (scripts_dir / name).write_text("# stub\n")
+
+    # environment.yml
+    (root / "environment.yml").write_text("name: video2pr\ndependencies:\n  - python\n")
+
+    # .claude/skills/video2pr/SKILL.md
+    claude_skill = root / ".claude" / "skills" / "video2pr"
+    claude_skill.mkdir(parents=True)
+    (claude_skill / "SKILL.md").write_text(SKILL_MD_CONTENT)
+
+    # .agents/skills/video2pr/SKILL.md + agents/openai.yaml
+    agents_skill = root / ".agents" / "skills" / "video2pr"
+    agents_skill.mkdir(parents=True)
+    (agents_skill / "SKILL.md").write_text(SKILL_MD_CONTENT)
+    agents_dir = agents_skill / "agents"
+    agents_dir.mkdir()
+    (agents_dir / "openai.yaml").write_text("# stub openai.yaml\n")
+
+    # .github/skills/video2pr/SKILL.md
+    gh_skill = root / ".github" / "skills" / "video2pr"
+    gh_skill.mkdir(parents=True)
+    (gh_skill / "SKILL.md").write_text(SKILL_MD_CONTENT)
+
+    # .github/agents/video2pr.agent.md
+    gh_agents = root / ".github" / "agents"
+    gh_agents.mkdir(parents=True)
+    (gh_agents / "video2pr.agent.md").write_text("# stub agent\n")
+
+    return root
+
+
+@pytest.fixture
+def target_dir(tmp_path):
+    """Fresh empty directory per test."""
+    d = tmp_path / "target"
+    d.mkdir()
+    return d

--- a/tests/test_check_update.py
+++ b/tests/test_check_update.py
@@ -1,0 +1,178 @@
+"""Tests for scripts/check_update.py."""
+
+import json
+import sys
+import urllib.error
+
+import pytest
+
+from conftest import import_script
+
+check_update = import_script("check_update.py")
+
+
+# ── Config loading ──────────────────────────────────────────────────
+
+
+def test_load_config_missing(tmp_path):
+    """No config file → SystemExit(0), stderr has CHECK_SKIPPED."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    with pytest.raises(SystemExit, match="0"):
+        check_update.load_config(scripts_dir)
+
+
+def test_load_config_valid(tmp_path):
+    """Write JSON to tmp_path, assert dict returned correctly."""
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    config = {"repo": "test/repo", "installed_at": "2025-01-01T00:00:00Z"}
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config))
+    result = check_update.load_config(scripts_dir)
+    assert result["repo"] == "test/repo"
+
+
+# ── Check mode ──────────────────────────────────────────────────────
+
+
+def test_check_up_to_date(monkeypatch, capsys):
+    """Commit date older than installed_at → UP_TO_DATE."""
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "installed_at": "2026-01-01T00:00:00Z",
+    }
+    monkeypatch.setattr(
+        check_update,
+        "fetch_json",
+        lambda url: [{"commit": {"committer": {"date": "2025-06-01T00:00:00Z"}}}],
+    )
+    result = check_update.check(config)
+    assert result is False
+    assert "UP_TO_DATE" in capsys.readouterr().out
+
+
+def test_check_update_available(monkeypatch, capsys):
+    """Commit date newer → UPDATE_AVAILABLE."""
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    monkeypatch.setattr(
+        check_update,
+        "fetch_json",
+        lambda url: [{"commit": {"committer": {"date": "2025-06-01T00:00:00Z"}}}],
+    )
+    result = check_update.check(config)
+    assert result is True
+    assert "UPDATE_AVAILABLE" in capsys.readouterr().out
+
+
+def test_check_no_commits(monkeypatch, capsys):
+    """Empty commit list → UP_TO_DATE."""
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    monkeypatch.setattr(check_update, "fetch_json", lambda url: [])
+    result = check_update.check(config)
+    assert result is False
+    assert "UP_TO_DATE" in capsys.readouterr().out
+
+
+# ── Apply mode ──────────────────────────────────────────────────────
+
+
+def test_apply_downloads_and_rewrites(tmp_path, monkeypatch, capsys):
+    """Set up fake skill dir, mock downloads, verify files and rewriting."""
+    skill_dir = tmp_path / ".claude" / "skills" / "video2pr"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "skill_dir": ".claude/skills/video2pr",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config))
+    (skill_dir / "SKILL.md").write_text("old content")
+
+    def mock_fetch_text(url):
+        if "SKILL.md" in url:
+            return "Run scripts/check_deps.py and environment.yml"
+        return f"# content for {url.split('/')[-1]}"
+
+    monkeypatch.setattr(check_update, "fetch_text", mock_fetch_text)
+    check_update.apply_update(config, scripts_dir)
+
+    # SKILL.md should have rewritten paths
+    skill_md = (skill_dir / "SKILL.md").read_text()
+    assert ".claude/skills/video2pr/scripts/" in skill_md
+    assert ".claude/skills/video2pr/environment.yml" in skill_md
+
+    # installed_at should be updated
+    new_config = json.loads((skill_dir / ".video2pr_install.json").read_text())
+    assert new_config["installed_at"] > "2025-01-01T00:00:00Z"
+
+    assert "UPDATED" in capsys.readouterr().out
+
+
+def test_apply_handles_http_error(tmp_path, monkeypatch, capsys):
+    """One download raises HTTPError, others succeed, no crash."""
+    skill_dir = tmp_path / ".claude" / "skills" / "video2pr"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "skill_dir": ".claude/skills/video2pr",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config))
+
+    call_count = 0
+
+    def mock_fetch_text(url):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+        return "# content"
+
+    monkeypatch.setattr(check_update, "fetch_text", mock_fetch_text)
+    # Should not raise
+    check_update.apply_update(config, scripts_dir)
+
+
+# ── Network error ───────────────────────────────────────────────────
+
+
+def test_main_network_error(tmp_path, monkeypatch, capsys):
+    """URLError → stdout CHECK_SKIPPED."""
+    # Set up config so load_config succeeds
+    skill_dir = tmp_path / "skill"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config))
+
+    monkeypatch.setattr(sys, "argv", ["check_update.py"])
+    monkeypatch.setattr(
+        check_update, "load_config", lambda _: config
+    )
+    def raise_url_error(url):
+        raise urllib.error.URLError("Network down")
+
+    monkeypatch.setattr(check_update, "fetch_json", raise_url_error)
+    check_update.main()
+    assert "CHECK_SKIPPED" in capsys.readouterr().out

--- a/tests/test_convert_transcript.py
+++ b/tests/test_convert_transcript.py
@@ -1,0 +1,124 @@
+"""Tests for scripts/convert_transcript.py."""
+
+import pytest
+
+from conftest import import_script
+
+ct = import_script("convert_transcript.py")
+
+
+# ── SBV timestamp parsing ──────────────────────────────────────────
+
+
+def test_sbv_timestamp_zero():
+    assert ct.parse_sbv_timestamp("0:00:00.000") == 0.0
+
+
+def test_sbv_timestamp_with_hours():
+    assert ct.parse_sbv_timestamp("1:23:45.678") == pytest.approx(5025.678)
+
+
+def test_sbv_timestamp_invalid():
+    assert ct.parse_sbv_timestamp("invalid") == 0.0
+
+
+# ── VTT timestamp parsing ──────────────────────────────────────────
+
+
+def test_vtt_timestamp_hh_mm_ss():
+    assert ct.parse_vtt_timestamp("01:23:45.678") == pytest.approx(5025.678)
+
+
+def test_vtt_timestamp_mm_ss():
+    assert ct.parse_vtt_timestamp("01:30.500") == pytest.approx(90.5)
+
+
+# ── SBV parsing ─────────────────────────────────────────────────────
+
+
+def test_parse_sbv_with_speaker():
+    content = "0:00:00.000,0:00:05.000\nAlice: Hello world"
+    segments = ct.parse_sbv(content)
+    assert len(segments) == 1
+    assert segments[0]["speaker"] == "Alice"
+    assert segments[0]["text"] == "Hello world"
+
+
+def test_parse_sbv_no_speaker():
+    content = "0:00:00.000,0:00:05.000\nJust some text here"
+    segments = ct.parse_sbv(content)
+    assert len(segments) == 1
+    assert segments[0]["speaker"] is None
+    assert segments[0]["text"] == "Just some text here"
+
+
+def test_parse_sbv_empty():
+    assert ct.parse_sbv("") == []
+
+
+# ── VTT parsing ─────────────────────────────────────────────────────
+
+
+def test_parse_vtt_with_v_tag():
+    content = (
+        "00:00:01.000 --> 00:00:05.000\n"
+        "<v Speaker>Some text</v>"
+    )
+    segments = ct.parse_vtt(content)
+    assert len(segments) == 1
+    assert segments[0]["speaker"] == "Speaker"
+    assert segments[0]["text"] == "Some text"
+
+
+def test_parse_vtt_strips_header():
+    content = (
+        "WEBVTT\n\n"
+        "00:00:01.000 --> 00:00:05.000\n"
+        "Hello world"
+    )
+    segments = ct.parse_vtt(content)
+    assert len(segments) == 1
+    assert segments[0]["text"] == "Hello world"
+
+
+# ── Google TXT parsing ──────────────────────────────────────────────
+
+
+def test_parse_google_txt_two_speakers():
+    content = (
+        "Alice (0:00:10)\n"
+        "First message\n"
+        "Bob (0:00:30)\n"
+        "Second message"
+    )
+    segments = ct.parse_google_txt(content)
+    assert len(segments) == 2
+    assert segments[0]["speaker"] == "Alice"
+    assert segments[0]["start"] == 10.0
+    # First segment end == second segment start
+    assert segments[0]["end"] == 30.0
+    assert segments[1]["speaker"] == "Bob"
+
+
+def test_parse_google_txt_last_segment_end():
+    content = "Alice (0:01:00)\nSome text"
+    segments = ct.parse_google_txt(content)
+    assert len(segments) == 1
+    assert segments[0]["end"] == 90.0  # start(60) + 30
+
+
+# ── Format detection ────────────────────────────────────────────────
+
+
+def test_detect_format_by_extension(tmp_path):
+    sbv = tmp_path / "test.sbv"
+    sbv.write_text("0:00:00.000,0:00:05.000\ntext")
+    assert ct.detect_format(sbv) == "sbv"
+
+    docx = tmp_path / "test.docx"
+    docx.write_text("")  # extension is enough
+    assert ct.detect_format(docx) == "teams_docx"
+
+    vtt = tmp_path / "test.vtt"
+    vtt.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:05.000\ntext")
+    assert ct.detect_format(vtt) == "vtt"

--- a/tests/test_extract_frame.py
+++ b/tests/test_extract_frame.py
@@ -1,0 +1,29 @@
+"""Tests for scripts/extract_frame.py — pure function tests only."""
+
+from conftest import import_script
+
+ef = import_script("extract_frame.py")
+
+
+def test_normalize_hh_mm_ss():
+    assert ef.normalize_timestamp("01:23:45") == "01:23:45"
+
+
+def test_normalize_mm_ss():
+    assert ef.normalize_timestamp("5:30") == "00:05:30"
+
+
+def test_normalize_seconds_int():
+    assert ef.normalize_timestamp("90") == "00:01:30"
+
+
+def test_normalize_seconds_float():
+    assert ef.normalize_timestamp("3661.5") == "01:01:01"
+
+
+def test_timestamp_to_filename():
+    assert ef.timestamp_to_filename("01:23:45") == "frame_01h23m45s.png"
+
+
+def test_timestamp_to_filename_zeros():
+    assert ef.timestamp_to_filename("00:00:00") == "frame_00h00m00s.png"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,182 @@
+"""Tests for install_video2pr.py."""
+
+import json
+import sys
+
+import pytest
+
+from conftest import import_script
+
+install = import_script("./install_video2pr.py")
+
+
+# ── Pure functions ──────────────────────────────────────────────────
+
+
+def test_rewrite_paths_scripts():
+    result = install.rewrite_paths(
+        "python scripts/check_deps.py", ".claude/skills/video2pr"
+    )
+    assert result == "python .claude/skills/video2pr/scripts/check_deps.py"
+
+
+def test_rewrite_paths_environment():
+    result = install.rewrite_paths(
+        "conda env create -f environment.yml", ".claude/skills/video2pr"
+    )
+    assert "conda env create -f .claude/skills/video2pr/environment.yml" == result
+
+
+def test_rewrite_paths_no_match():
+    text = "nothing to rewrite here"
+    assert install.rewrite_paths(text, ".claude/skills/video2pr") == text
+
+
+# ── Source validation ───────────────────────────────────────────────
+
+
+def test_check_source_files_all_present(fake_repo, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    assert install.check_source_files() == []
+
+
+def test_check_source_files_missing_script(tmp_path, monkeypatch):
+    # Use an isolated repo to avoid mutating the session-scoped fake_repo
+    from conftest import SCRIPT_NAMES, SKILL_MD_CONTENT
+
+    root = tmp_path / "repo"
+    scripts_dir = root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    for name in SCRIPT_NAMES:
+        if name != "check_deps.py":
+            (scripts_dir / name).write_text("# stub\n")
+    (root / "environment.yml").write_text("name: video2pr\n")
+    for skill_path in [
+        ".claude/skills/video2pr",
+        ".agents/skills/video2pr",
+        ".github/skills/video2pr",
+    ]:
+        d = root / skill_path
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(SKILL_MD_CONTENT)
+
+    monkeypatch.setattr(install, "REPO_ROOT", root)
+    errors = install.check_source_files()
+    assert any("check_deps.py" in e for e in errors)
+
+
+# ── Conflict detection ──────────────────────────────────────────────
+
+
+def test_get_conflicts_empty_target(target_dir):
+    assert install.get_conflicts(target_dir, ["claude-code"]) == []
+
+
+def test_get_conflicts_existing_dir(target_dir):
+    (target_dir / ".claude" / "skills" / "video2pr").mkdir(parents=True)
+    conflicts = install.get_conflicts(target_dir, ["claude-code"])
+    assert len(conflicts) == 1
+    assert "video2pr" in conflicts[0]
+
+
+# ── Single assistant install ────────────────────────────────────────
+
+
+def test_install_claude_code(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    installed = install.install_assistant(target_dir, "claude-code", dry_run=False)
+
+    skill_dir = target_dir / ".claude" / "skills" / "video2pr"
+    # 7 scripts + env + SKILL.md + config
+    assert len(installed) == 10
+    assert (skill_dir / "scripts" / "transcribe.py").exists()
+    assert (skill_dir / "environment.yml").exists()
+
+    # SKILL.md should be rewritten
+    skill_md = (skill_dir / "SKILL.md").read_text()
+    assert ".claude/skills/video2pr/scripts/" in skill_md
+    assert ".claude/skills/video2pr/environment.yml" in skill_md
+
+    # Config JSON
+    config_path = skill_dir / ".video2pr_install.json"
+    assert config_path.exists()
+    config = json.loads(config_path.read_text())
+    assert config["repo"] == "douglas125/video2PR"
+    assert config["skill_dir"] == ".claude/skills/video2pr"
+
+
+def test_install_codex_has_openai_yaml(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    install.install_assistant(target_dir, "codex", dry_run=False)
+    assert (
+        target_dir / ".agents" / "skills" / "video2pr" / "agents" / "openai.yaml"
+    ).exists()
+
+
+def test_install_copilot_has_agent_md(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    install.install_assistant(target_dir, "copilot", dry_run=False)
+    assert (target_dir / ".github" / "agents" / "video2pr.agent.md").exists()
+
+
+# ── Dry run ─────────────────────────────────────────────────────────
+
+
+def test_dry_run_creates_no_files(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    install.install_assistant(target_dir, "claude-code", dry_run=True)
+    # target_dir should still be empty (no child dirs)
+    assert list(target_dir.iterdir()) == []
+
+
+# ── CLI integration ─────────────────────────────────────────────────
+
+
+def test_main_nonexistent_target(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["install_video2pr.py", "/no/such/path"])
+    with pytest.raises(SystemExit, match="1"):
+        install.main()
+
+
+def test_main_conflict_without_force(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    (target_dir / ".claude" / "skills" / "video2pr").mkdir(parents=True)
+    monkeypatch.setattr(
+        sys, "argv", ["install_video2pr.py", str(target_dir)]
+    )
+    with pytest.raises(SystemExit, match="1"):
+        install.main()
+
+
+def test_main_force_overwrites(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    # Pre-create a stale file
+    skill_dir = target_dir / ".claude" / "skills" / "video2pr"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "stale.txt").write_text("old")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_video2pr.py", str(target_dir), "--force"],
+    )
+    install.main()
+
+    # Stale file should be gone, fresh install present
+    assert not (skill_dir / "stale.txt").exists()
+    assert (skill_dir / "SKILL.md").exists()
+
+
+def test_main_all_three_assistants(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_video2pr.py", str(target_dir)],
+    )
+    install.main()
+
+    assert (target_dir / ".claude" / "skills" / "video2pr" / "SKILL.md").exists()
+    assert (target_dir / ".agents" / "skills" / "video2pr" / "SKILL.md").exists()
+    assert (target_dir / ".github" / "skills" / "video2pr" / "SKILL.md").exists()
+    assert (target_dir / ".github" / "agents" / "video2pr.agent.md").exists()

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,106 @@
+"""Tests for scripts/transcribe.py — pure function tests only."""
+
+import pytest
+
+from conftest import import_script
+
+tr = import_script("transcribe.py")
+
+
+# ── SRT timestamp round-trips ──────────────────────────────────────
+
+
+def test_parse_srt_timestamp():
+    assert tr.parse_srt_timestamp("01:23:45,678") == pytest.approx(5025.678)
+
+
+def test_format_srt_timestamp():
+    assert tr.format_srt_timestamp(5025.5) == "01:23:45,500"
+
+
+def test_srt_timestamp_roundtrip():
+    for ts in ["00:00:00,000", "00:05:30,500", "02:00:00,000"]:
+        assert tr.format_srt_timestamp(tr.parse_srt_timestamp(ts)) == ts
+
+
+def test_parse_srt_invalid():
+    assert tr.parse_srt_timestamp("invalid") == 0.0
+
+
+# ── SRT offsetting ──────────────────────────────────────────────────
+
+
+def test_offset_srt_shifts_timestamps():
+    srt = (
+        "1\n"
+        "00:00:10,000 --> 00:00:20,000\n"
+        "Hello\n\n"
+        "2\n"
+        "00:00:30,000 --> 00:00:40,000\n"
+        "World\n"
+    )
+    result, _ = tr.offset_srt(srt, 60.0, 1)
+    assert "00:01:10,000 --> 00:01:20,000" in result
+    assert "00:01:30,000 --> 00:01:40,000" in result
+
+
+def test_offset_srt_renumbers():
+    srt = (
+        "1\n"
+        "00:00:10,000 --> 00:00:20,000\n"
+        "Hello\n\n"
+        "2\n"
+        "00:00:30,000 --> 00:00:40,000\n"
+        "World\n"
+    )
+    result, _ = tr.offset_srt(srt, 0.0, 5)
+    lines = result.strip().split("\n")
+    assert lines[0] == "5"
+
+
+def test_offset_srt_returns_next_index():
+    srt = (
+        "1\n"
+        "00:00:10,000 --> 00:00:20,000\n"
+        "Hello\n\n"
+        "2\n"
+        "00:00:30,000 --> 00:00:40,000\n"
+        "World\n"
+    )
+    _, next_idx = tr.offset_srt(srt, 0.0, 1)
+    assert next_idx == 3
+
+
+# ── JSON segment offsetting ─────────────────────────────────────────
+
+
+def test_offset_json_basic():
+    segments = [
+        {
+            "start": 10.0,
+            "end": 20.0,
+            "text": "Hello",
+            "words": [
+                {"start": 10.0, "end": 15.0, "word": "Hello"},
+            ],
+        }
+    ]
+    result = tr.offset_json_segments(segments, 120.0)
+    assert result[0]["start"] == pytest.approx(130.0)
+    assert result[0]["end"] == pytest.approx(140.0)
+    assert result[0]["words"][0]["start"] == pytest.approx(130.0)
+
+
+def test_offset_json_no_words():
+    segments = [{"start": 5.0, "end": 10.0, "text": "No words key"}]
+    result = tr.offset_json_segments(segments, 100.0)
+    assert result[0]["start"] == pytest.approx(105.0)
+    assert "words" not in result[0]
+
+
+# ── Elapsed formatting ──────────────────────────────────────────────
+
+
+def test_format_elapsed():
+    assert tr.format_elapsed(45.3) == "45.3s"
+    assert tr.format_elapsed(125.7) == "2m 5.7s"


### PR DESCRIPTION
## Summary
- Add pytest-based test suite covering all pure-function logic across 5 modules (52 tests total)
- Tests run without network, ffmpeg, or whisper — only pytest needed
- Add `__pycache__/` and `*.pyc` to `.gitignore`
- Add `pytest` to conda environment pip deps

## Test plan
- [x] `conda run -n video2pr pytest -v` — 52 passed in 0.08s
- [ ] Verify no tests require external dependencies (network, ffmpeg, whisper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)