### PR TITLE
Add GitHub Actions CI for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest -v


### PR DESCRIPTION
## Summary
- Add CI workflow running pytest on every push/PR to main
- Matrix: ubuntu-latest + windows-latest × Python 3.12, 3.13, 3.14 (6 jobs)
- No conda/ffmpeg/whisper needed — just pip install pytest

## Test plan
- [ ] Verify all 6 matrix jobs pass on this PR
- [ ] Configure branch protection after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)