### PR TITLE
Add GPU-aware PyTorch detection for Whisper transcription

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -48,6 +48,17 @@ conda env create -f environment.yml
 conda activate video2pr
 ```
 
+After dependencies pass, check GPU status:
+
+```bash
+conda run -n video2pr python scripts/check_gpu.py
+```
+
+Interpret the JSON output:
+- If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
+
 ## Phase 2: Validate Input
 
 The user provides a video file path as the argument. Verify:

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -49,6 +49,17 @@ conda env create -f environment.yml
 conda activate video2pr
 ```
 
+After dependencies pass, check GPU status:
+
+```bash
+conda run -n video2pr python scripts/check_gpu.py
+```
+
+Interpret the JSON output:
+- If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
+
 ## Phase 2: Validate Input
 
 The user provides a video file path as the argument. Verify:

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -48,6 +48,17 @@ conda env create -f environment.yml
 conda activate video2pr
 ```
 
+After dependencies pass, check GPU status:
+
+```bash
+conda run -n video2pr python scripts/check_gpu.py
+```
+
+Interpret the JSON output:
+- If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
+
 ## Phase 2: Validate Input
 
 The user provides a video file path as the argument. Verify:

--- a/install_video2pr.py
+++ b/install_video2pr.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parent
 
 SCRIPT_NAMES = [
     "check_deps.py",
+    "check_gpu.py",
     "check_update.py",
     "convert_transcript.py",
     "extract_audio.py",

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -108,6 +108,37 @@ def main():
 
     print("\nAll dependencies found.")
 
+    # GPU status check
+    gpu_script = Path(__file__).resolve().parent / "check_gpu.py"
+    if gpu_script.exists():
+        gpu_result = subprocess.run(
+            ["conda", "run", "-n", ENV_NAME, "python", str(gpu_script)],
+            capture_output=True,
+            text=True,
+        )
+        if gpu_result.returncode == 0:
+            try:
+                gpu_info = json.loads(gpu_result.stdout)
+                device = gpu_info.get("device", "cpu")
+                gpu_name = gpu_info.get("gpu_name")
+                cuda_version = gpu_info.get("cuda_version")
+                available = gpu_info.get("torch_device_available", False)
+                install_cmd = gpu_info.get("install_command")
+
+                if device == "cuda" and available:
+                    print(f"  GPU: {gpu_name} (CUDA {cuda_version}) — OK")
+                elif device == "mps" and available:
+                    print("  GPU: Apple Silicon (MPS) — OK")
+                elif gpu_name and not available:
+                    print(f"  GPU: {gpu_name} detected, PyTorch is CPU-only")
+                    if install_cmd:
+                        print(f"  To enable GPU acceleration (~5-20x faster transcription):")
+                        print(f"    {install_cmd}")
+                else:
+                    print("  GPU: CPU only")
+            except (json.JSONDecodeError, KeyError):
+                print("  GPU: detection failed")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/check_gpu.py
+++ b/scripts/check_gpu.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Detect GPU hardware and PyTorch device availability.
+
+Outputs structured JSON to stdout. Also exposes a check_gpu() function
+for programmatic use.
+"""
+
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_nvidia_smi():
+    """Find the nvidia-smi executable path, with Windows fallback.
+
+    Returns the path string or None.
+    """
+    exe = shutil.which("nvidia-smi")
+    if exe is None and platform.system() == "Windows":
+        fallback = r"C:\Windows\System32\nvidia-smi.exe"
+        if Path(fallback).exists():
+            exe = fallback
+    return exe
+
+
+def _run_nvidia_smi_query():
+    """Query nvidia-smi for GPU name and driver version.
+
+    Returns (gpu_name, driver_version) or (None, None) on failure.
+    """
+    exe = _find_nvidia_smi()
+    if exe is None:
+        return None, None
+
+    try:
+        result = subprocess.run(
+            [exe, "--query-gpu=name,driver_version", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None, None
+        line = result.stdout.strip().split("\n")[0]
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+        return None, None
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None, None
+
+
+def _parse_cuda_version():
+    """Parse CUDA version from nvidia-smi header output.
+
+    Returns version string like "12.4" or None.
+    """
+    exe = _find_nvidia_smi()
+    if exe is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            [exe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.split("\n"):
+            match = re.search(r"CUDA Version:\s+([\d.]+)", line)
+            if match:
+                return match.group(1)
+        return None
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _map_cuda_to_wheel(cuda_version_str):
+    """Map a CUDA version string to the PyTorch wheel suffix.
+
+    Returns e.g. "cu124", "cu121", "cu118".
+    """
+    try:
+        parts = cuda_version_str.split(".")
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError):
+        return "cu124"  # default to latest supported
+
+    if major >= 13 or (major == 12 and minor >= 4):
+        return "cu124"
+    elif major == 12 and minor >= 1:
+        return "cu121"
+    else:
+        return "cu118"
+
+
+def _check_torch():
+    """Check PyTorch installation and device availability.
+
+    Returns (installed, version, cuda_available, mps_available).
+    """
+    try:
+        import torch
+
+        cuda_avail = torch.cuda.is_available()
+        mps_avail = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+        return True, torch.__version__, cuda_avail, mps_avail
+    except ImportError:
+        return False, None, False, False
+
+
+def check_gpu():
+    """Detect GPU hardware and PyTorch device status.
+
+    Returns a dict with detection results.
+    """
+    plat = platform.system()
+    arch = platform.machine()
+
+    # Detect NVIDIA GPU
+    gpu_name, _ = _run_nvidia_smi_query()
+    cuda_version = _parse_cuda_version() if gpu_name else None
+
+    # Detect Apple Silicon
+    is_apple_silicon = plat == "Darwin" and arch == "arm64"
+
+    # Check PyTorch
+    torch_installed, torch_version, cuda_avail, mps_avail = _check_torch()
+
+    # Determine device and availability
+    if cuda_avail:
+        device = "cuda"
+        torch_device_available = True
+    elif mps_avail:
+        device = "mps"
+        torch_device_available = True
+    else:
+        device = "cpu"
+        torch_device_available = False
+
+    # Build install command if GPU exists but torch can't use it
+    install_command = None
+    if gpu_name and not cuda_avail:
+        # NVIDIA GPU present but torch can't use CUDA
+        wheel_tag = _map_cuda_to_wheel(cuda_version) if cuda_version else "cu124"
+        install_command = (
+            f"pip install torch torchvision torchaudio"
+            f" --index-url https://download.pytorch.org/whl/{wheel_tag}"
+        )
+    elif is_apple_silicon and not mps_avail:
+        install_command = "pip install --upgrade torch torchvision torchaudio"
+
+    # Build message
+    if device == "cuda":
+        msg = f"GPU acceleration: {gpu_name} via CUDA {cuda_version or 'unknown'}"
+    elif device == "mps":
+        msg = "GPU acceleration: Apple Silicon (MPS)"
+    elif gpu_name:
+        msg = f"GPU detected ({gpu_name}) but PyTorch is CPU-only"
+    elif is_apple_silicon:
+        msg = "Apple Silicon detected but MPS not available in PyTorch"
+    else:
+        msg = "Running on CPU (no GPU detected)"
+
+    return {
+        "platform": plat,
+        "arch": arch,
+        "device": device,
+        "gpu_name": gpu_name,
+        "cuda_version": cuda_version,
+        "torch_installed": torch_installed,
+        "torch_version": torch_version,
+        "torch_device_available": torch_device_available,
+        "install_command": install_command,
+        "message": msg,
+    }
+
+
+def main():
+    result = check_gpu()
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_gpu.py
+++ b/tests/test_check_gpu.py
@@ -1,0 +1,232 @@
+"""Tests for scripts/check_gpu.py."""
+
+import json
+import subprocess
+import sys
+import types
+
+from conftest import import_script
+
+gpu = import_script("check_gpu.py")
+
+
+# ── Helper to build a fake nvidia-smi ──────────────────────────────
+
+
+def _fake_nvidia_smi(gpu_name="NVIDIA RTX 3080", driver="535.129.03", cuda_ver="12.4"):
+    """Return a side_effect function for monkeypatching subprocess.run."""
+    query_stdout = f"{gpu_name}, {driver}\n"
+    header_stdout = (
+        f"| NVIDIA-SMI {driver}   Driver Version: {driver}"
+        f"   CUDA Version: {cuda_ver}  |\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        if any("--query-gpu" in arg for arg in cmd):
+            return subprocess.CompletedProcess(cmd, 0, stdout=query_stdout, stderr="")
+        # Plain nvidia-smi (header)
+        return subprocess.CompletedProcess(cmd, 0, stdout=header_stdout, stderr="")
+
+    return fake_run
+
+
+def _nvidia_smi_missing(cmd, **kwargs):
+    raise FileNotFoundError("nvidia-smi not found")
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+def test_nvidia_cuda_working(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(subprocess, "run", _fake_nvidia_smi())
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: True)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["device"] == "cuda"
+    assert result["torch_device_available"] is True
+    assert result["install_command"] is None
+    assert result["gpu_name"] == "NVIDIA RTX 3080"
+    assert result["cuda_version"] == "12.4"
+
+
+def test_nvidia_torch_cpu_only(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(subprocess, "run", _fake_nvidia_smi())
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["device"] == "cpu"
+    assert result["torch_device_available"] is False
+    assert result["install_command"] is not None
+    assert "cu124" in result["install_command"]
+
+
+def test_nvidia_torch_missing(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(subprocess, "run", _fake_nvidia_smi())
+
+    # Setting a module to None in sys.modules causes import to raise ImportError
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    result = gpu.check_gpu()
+    assert result["torch_installed"] is False
+    assert result["install_command"] is not None
+
+
+def test_apple_silicon_mps(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr(subprocess, "run", _nvidia_smi_missing)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: True)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["device"] == "mps"
+    assert result["torch_device_available"] is True
+    assert result["install_command"] is None
+
+
+def test_apple_silicon_no_mps(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr(subprocess, "run", _nvidia_smi_missing)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.1.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["device"] == "cpu"
+    assert result["install_command"] is not None
+    assert "upgrade" in result["install_command"]
+
+
+def test_cpu_only_no_gpu(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr(subprocess, "run", _nvidia_smi_missing)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["device"] == "cpu"
+    assert result["install_command"] is None
+
+
+def test_nvidia_smi_parse_error(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+
+    def garbage_nvidia_smi(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="garbage output\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", garbage_nvidia_smi)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    # Should not crash
+    result = gpu.check_gpu()
+    assert result["device"] == "cpu"
+
+
+def test_cuda_version_mapping():
+    assert gpu._map_cuda_to_wheel("11.8") == "cu118"
+    assert gpu._map_cuda_to_wheel("12.1") == "cu121"
+    assert gpu._map_cuda_to_wheel("12.3") == "cu121"
+    assert gpu._map_cuda_to_wheel("12.4") == "cu124"
+    assert gpu._map_cuda_to_wheel("12.6") == "cu124"
+    assert gpu._map_cuda_to_wheel("13.0") == "cu124"
+
+
+def test_windows_nvidia_smi_path(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr("platform.machine", lambda: "AMD64")
+    monkeypatch.setattr("shutil.which", lambda x: None)
+
+    # Monkeypatch the helpers to simulate Windows detection results
+    monkeypatch.setattr(
+        gpu, "_run_nvidia_smi_query", lambda: ("NVIDIA RTX 4090", "545.0")
+    )
+    monkeypatch.setattr(gpu, "_parse_cuda_version", lambda: "12.4")
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    result = gpu.check_gpu()
+    assert result["gpu_name"] == "NVIDIA RTX 4090"
+    assert result["install_command"] is not None
+    assert "cu124" in result["install_command"]
+
+
+def test_json_output(monkeypatch, capsys):
+    """check_gpu.py main() outputs valid JSON."""
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr(subprocess, "run", _nvidia_smi_missing)
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__version__ = "2.3.0"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    gpu.main()
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "device" in data
+    assert "message" in data

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -87,8 +87,8 @@ def test_install_claude_code(fake_repo, target_dir, monkeypatch):
     installed = install.install_assistant(target_dir, "claude-code", dry_run=False)
 
     skill_dir = target_dir / ".claude" / "skills" / "video2pr"
-    # 7 scripts + env + SKILL.md + config
-    assert len(installed) == 10
+    # 8 scripts + env + SKILL.md + config
+    assert len(installed) == 11
     assert (skill_dir / "scripts" / "transcribe.py").exists()
     assert (skill_dir / "environment.yml").exists()
 


### PR DESCRIPTION
## Summary

- Add `scripts/check_gpu.py` that detects NVIDIA GPUs (via nvidia-smi), Apple Silicon (MPS), and checks if PyTorch can use them — outputs structured JSON with device info and install command if needed
- Integrate GPU status into `scripts/check_deps.py` so users see GPU availability after dependency checks (informational only, never blocks)
- Add GPU check phase to all three SKILL.md files so coding assistants surface the install command when GPU acceleration is available but unused
- Add `check_gpu.py` to installer script list and update test assertions

## Test plan

- [x] 10 new tests in `tests/test_check_gpu.py` covering NVIDIA CUDA working, CPU-only torch, missing torch, Apple Silicon MPS/no-MPS, CPU-only, parse errors, CUDA version mapping, Windows fallback, JSON output
- [x] All 62 tests pass (`pytest tests/ -v`)
- [ ] Manual: `conda run -n video2pr python scripts/check_gpu.py` returns valid JSON
- [ ] Manual: `python scripts/check_deps.py` shows GPU status line after dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)