### PR TITLE
Display GPU/update notices before transcription

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -56,7 +56,7 @@ conda run -n video2pr python scripts/check_gpu.py
 
 Interpret the JSON output:
 - If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
-- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `torch_device_available` is `false` and `install_command` is not null: briefly note that GPU is available but PyTorch can't use it yet. Do NOT prompt to install here — the actionable prompt will appear in Phase 3c, right before transcription when it matters most.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input
@@ -111,6 +111,14 @@ If an external transcript was found in Phase 2:
 If no external transcript → continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
+
+**Pre-transcription check:** Before starting transcription (the longest step), re-check GPU status and surface any pending notices so the user can act on them before waiting:
+
+Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
+
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
+- Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -57,7 +57,7 @@ conda run -n video2pr python scripts/check_gpu.py
 
 Interpret the JSON output:
 - If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
-- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `torch_device_available` is `false` and `install_command` is not null: briefly note that GPU is available but PyTorch can't use it yet. Do NOT prompt to install here — the actionable prompt will appear in Phase 3c, right before transcription when it matters most.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input
@@ -112,6 +112,14 @@ If an external transcript was found in Phase 2:
 If no external transcript → continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
+
+**Pre-transcription check:** Before starting transcription (the longest step), re-check GPU status and surface any pending notices so the user can act on them before waiting:
+
+Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
+
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
+- Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -56,7 +56,7 @@ conda run -n video2pr python scripts/check_gpu.py
 
 Interpret the JSON output:
 - If `torch_device_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
-- If `torch_device_available` is `false` and `install_command` is not null: tell the user their GPU can be used but PyTorch can't access it. Show the install command and note the approximate speedup (~5-20x). Ask if they want to install it now or continue with CPU. Do NOT auto-install.
+- If `torch_device_available` is `false` and `install_command` is not null: briefly note that GPU is available but PyTorch can't use it yet. Do NOT prompt to install here — the actionable prompt will appear in Phase 3c, right before transcription when it matters most.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input
@@ -111,6 +111,14 @@ If an external transcript was found in Phase 2:
 If no external transcript → continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
+
+**Pre-transcription check:** Before starting transcription (the longest step), re-check GPU status and surface any pending notices so the user can act on them before waiting:
+
+Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
+
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
+- Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash


### PR DESCRIPTION
## Summary
- Moves the interactive GPU install prompt from Phase 1 to Phase 3c, right before Whisper transcription starts — the moment it matters most
- Phase 1 now briefly notes GPU status without prompting, avoiding the notice scrolling off screen before the slow step
- Re-displays any pending update notice from Phase 0 at the same point
- Applied consistently across all three SKILL.md files (Claude Code, Codex CLI, Copilot CLI)

## Test plan
- [ ] Run `/video2pr` on a machine where GPU is detected but PyTorch is CPU-only — confirm prominent warning appears before transcription
- [ ] Run on a machine with GPU properly configured — confirm no extra prompts
- [ ] Run with `UPDATE_AVAILABLE` — confirm reminder appears before transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)