### PR TITLE
Add Windows conda PATH discovery and broaden update checker

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -41,6 +41,8 @@ Run the dependency checker:
 python scripts/check_deps.py
 ```
 
+**Capture the conda path:** Look for the `CONDA_PATH: <path>` line in the output. Use that path instead of bare `conda` in **all** subsequent commands in this skill (e.g., `<conda-path> run -n video2pr ...`). If no `CONDA_PATH:` line appears (e.g., conda is missing), use `conda` as-is.
+
 If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
@@ -51,7 +53,7 @@ conda activate video2pr
 After dependencies pass, check GPU status:
 
 ```bash
-conda run -n video2pr python scripts/check_gpu.py
+<conda-path> run -n video2pr python scripts/check_gpu.py
 ```
 
 Interpret the JSON output:

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -42,6 +42,8 @@ Run the dependency checker:
 python scripts/check_deps.py
 ```
 
+**Capture the conda path:** Look for the `CONDA_PATH: <path>` line in the output. Use that path instead of bare `conda` in **all** subsequent commands in this skill (e.g., `<conda-path> run -n video2pr ...`). If no `CONDA_PATH:` line appears (e.g., conda is missing), use `conda` as-is.
+
 If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
@@ -52,7 +54,7 @@ conda activate video2pr
 After dependencies pass, check GPU status:
 
 ```bash
-conda run -n video2pr python scripts/check_gpu.py
+<conda-path> run -n video2pr python scripts/check_gpu.py
 ```
 
 Interpret the JSON output:

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -41,6 +41,8 @@ Run the dependency checker:
 python scripts/check_deps.py
 ```
 
+**Capture the conda path:** Look for the `CONDA_PATH: <path>` line in the output. Use that path instead of bare `conda` in **all** subsequent commands in this skill (e.g., `<conda-path> run -n video2pr ...`). If no `CONDA_PATH:` line appears (e.g., conda is missing), use `conda` as-is.
+
 If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
@@ -51,7 +53,7 @@ conda activate video2pr
 After dependencies pass, check GPU status:
 
 ```bash
-conda run -n video2pr python scripts/check_gpu.py
+<conda-path> run -n video2pr python scripts/check_gpu.py
 ```
 
 Interpret the JSON output:

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -7,6 +7,8 @@ This script itself runs from system Python — no conda activation needed.
 """
 
 import json
+import platform
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -17,11 +19,48 @@ CLI_TOOLS = ["ffmpeg", "ffprobe", "whisper"]
 PYTHON_IMPORTS = {"python-docx": "docx"}
 
 
+def find_conda():
+    """Find the conda executable path, with Windows fallback.
+
+    Tries shutil.which first. On Windows, checks common install locations
+    if conda is not on PATH (e.g. Git Bash sessions).
+
+    Returns the path string or None.
+    """
+    exe = shutil.which("conda")
+    if exe is not None:
+        return exe
+
+    if platform.system() != "Windows":
+        return None
+
+    # Common Windows conda install locations
+    home = Path.home()
+    candidates = [
+        home / "miniconda3" / "condabin" / "conda.bat",
+        home / "anaconda3" / "condabin" / "conda.bat",
+        home / "Miniconda3" / "condabin" / "conda.bat",
+        home / "Anaconda3" / "condabin" / "conda.bat",
+        Path(r"C:\ProgramData\miniconda3\condabin\conda.bat"),
+        Path(r"C:\ProgramData\anaconda3\condabin\conda.bat"),
+        Path(r"C:\ProgramData\Miniconda3\condabin\conda.bat"),
+        Path(r"C:\ProgramData\Anaconda3\condabin\conda.bat"),
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    return None
+
+
 def conda_available():
-    """Check if conda is on the system PATH and working."""
+    """Check if conda is findable and working."""
+    conda_path = find_conda()
+    if conda_path is None:
+        return False
     try:
         result = subprocess.run(
-            ["conda", "--version"],
+            [conda_path, "--version"],
             capture_output=True,
             text=True,
         )
@@ -30,10 +69,10 @@ def conda_available():
         return False
 
 
-def env_exists(env_name):
+def env_exists(env_name, conda_path="conda"):
     """Check if a conda environment exists."""
     result = subprocess.run(
-        ["conda", "env", "list", "--json"],
+        [conda_path, "env", "list", "--json"],
         capture_output=True,
         text=True,
     )
@@ -43,7 +82,7 @@ def env_exists(env_name):
     return any(Path(e).name == env_name for e in envs)
 
 
-def check_deps_in_env():
+def check_deps_in_env(conda_path="conda"):
     """Check all CLI tools and Python imports in a single conda run call.
 
     Returns (cli_results, import_results) where each is a dict of name -> bool.
@@ -61,7 +100,7 @@ def check_deps_in_env():
     script = "import shutil, json\nresults = {}\n" + "\n".join(checks) + "\nprint(json.dumps(results))"
 
     result = subprocess.run(
-        ["conda", "run", "-n", ENV_NAME, "python", "-c", script],
+        [conda_path, "run", "-n", ENV_NAME, "python", "-c", script],
         capture_output=True,
         text=True,
     )
@@ -76,15 +115,17 @@ def check_deps_in_env():
 def main():
     print("=== video2pr dependency check ===")
 
-    if not conda_available():
+    conda_path = find_conda()
+    if conda_path is None:
         print("  conda: MISSING")
         print("\nMISSING: conda")
         print("\nInstall conda/miniconda first, then run:")
         print("  conda env create -f environment.yml")
         sys.exit(1)
     print("  conda: OK")
+    print(f"CONDA_PATH: {conda_path}")
 
-    if not env_exists(ENV_NAME):
+    if not env_exists(ENV_NAME, conda_path):
         print(f"  conda env ({ENV_NAME}): MISSING")
         print(f"\nMISSING: conda env ({ENV_NAME})")
         print("\nTo set up the environment:")
@@ -92,7 +133,7 @@ def main():
         sys.exit(1)
     print(f"  conda env ({ENV_NAME}): OK")
 
-    results = check_deps_in_env()
+    results = check_deps_in_env(conda_path)
     missing = []
     for name, found in results.items():
         status = "OK" if found else "MISSING"
@@ -112,7 +153,7 @@ def main():
     gpu_script = Path(__file__).resolve().parent / "check_gpu.py"
     if gpu_script.exists():
         gpu_result = subprocess.run(
-            ["conda", "run", "-n", ENV_NAME, "python", str(gpu_script)],
+            [conda_path, "run", "-n", ENV_NAME, "python", str(gpu_script)],
             capture_output=True,
             text=True,
         )

--- a/scripts/check_update.py
+++ b/scripts/check_update.py
@@ -59,22 +59,27 @@ def check(config: dict) -> bool:
     repo = config["repo"]
     branch = config.get("branch", "main")
     installed_at = config["installed_at"]
+    skill_dir = config.get("skill_dir", "")
 
-    url = GITHUB_API.format(repo=repo) + f"?path=scripts&sha={branch}&per_page=1"
-    commits = fetch_json(url)
+    # Check all paths that get updated: scripts/, environment.yml, and SKILL.md
+    paths_to_check = ["scripts", "environment.yml"]
+    source_path = SKILL_MD_SOURCES.get(skill_dir)
+    if source_path:
+        paths_to_check.append(source_path)
 
-    if not commits:
-        print("UP_TO_DATE")
-        return False
+    for path in paths_to_check:
+        url = GITHUB_API.format(repo=repo) + f"?path={path}&sha={branch}&per_page=1"
+        commits = fetch_json(url)
+        if not commits:
+            continue
+        latest_date = commits[0]["commit"]["committer"]["date"]
+        if latest_date > installed_at:
+            print(f"UPDATE_AVAILABLE: New changes since {installed_at}. "
+                  f"Run with --apply to update.")
+            return True
 
-    latest_date = commits[0]["commit"]["committer"]["date"]
-    if latest_date <= installed_at:
-        print("UP_TO_DATE")
-        return False
-
-    print(f"UPDATE_AVAILABLE: New changes since {installed_at}. "
-          f"Run with --apply to update.")
-    return True
+    print("UP_TO_DATE")
+    return False
 
 
 def rewrite_paths(content: str, skill_dir: str) -> str:

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/check_deps.py — conda path discovery."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make scripts/ importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import check_deps
+
+
+class TestFindConda:
+    """Tests for find_conda() path discovery."""
+
+    def test_which_finds_conda_returns_immediately(self):
+        """When shutil.which finds conda, return it on any platform."""
+        with patch("check_deps.shutil.which", return_value="/usr/bin/conda"):
+            result = check_deps.find_conda()
+        assert result == "/usr/bin/conda"
+
+    def test_which_finds_conda_on_windows(self):
+        """When shutil.which finds conda on Windows, return it without fallback."""
+        with (
+            patch("check_deps.shutil.which", return_value=r"C:\Users\me\miniconda3\condabin\conda.bat"),
+            patch("check_deps.platform.system", return_value="Windows"),
+        ):
+            result = check_deps.find_conda()
+        assert result == r"C:\Users\me\miniconda3\condabin\conda.bat"
+
+    def test_not_on_path_non_windows_returns_none(self):
+        """On non-Windows, if shutil.which fails, return None."""
+        with (
+            patch("check_deps.shutil.which", return_value=None),
+            patch("check_deps.platform.system", return_value="Linux"),
+        ):
+            result = check_deps.find_conda()
+        assert result is None
+
+    def test_not_on_path_macos_returns_none(self):
+        """On macOS, if shutil.which fails, return None."""
+        with (
+            patch("check_deps.shutil.which", return_value=None),
+            patch("check_deps.platform.system", return_value="Darwin"),
+        ):
+            result = check_deps.find_conda()
+        assert result is None
+
+    def test_windows_fallback_miniconda3(self, tmp_path):
+        """On Windows, find conda.bat in ~/miniconda3/condabin/."""
+        condabin = tmp_path / "miniconda3" / "condabin"
+        condabin.mkdir(parents=True)
+        conda_bat = condabin / "conda.bat"
+        conda_bat.touch()
+
+        with (
+            patch("check_deps.shutil.which", return_value=None),
+            patch("check_deps.platform.system", return_value="Windows"),
+            patch("check_deps.Path.home", return_value=tmp_path),
+        ):
+            result = check_deps.find_conda()
+        assert result == str(conda_bat)
+
+    def test_windows_fallback_anaconda3(self, tmp_path):
+        """On Windows, find conda.bat in ~/anaconda3/condabin/."""
+        condabin = tmp_path / "anaconda3" / "condabin"
+        condabin.mkdir(parents=True)
+        conda_bat = condabin / "conda.bat"
+        conda_bat.touch()
+
+        with (
+            patch("check_deps.shutil.which", return_value=None),
+            patch("check_deps.platform.system", return_value="Windows"),
+            patch("check_deps.Path.home", return_value=tmp_path),
+        ):
+            result = check_deps.find_conda()
+        assert result == str(conda_bat)
+
+    def test_windows_no_fallback_found(self, tmp_path):
+        """On Windows with no conda anywhere, return None."""
+        with (
+            patch("check_deps.shutil.which", return_value=None),
+            patch("check_deps.platform.system", return_value="Windows"),
+            patch("check_deps.Path.home", return_value=tmp_path),
+        ):
+            result = check_deps.find_conda()
+        assert result is None

--- a/tests/test_check_update.py
+++ b/tests/test_check_update.py
@@ -84,6 +84,30 @@ def test_check_no_commits(monkeypatch, capsys):
     assert "UP_TO_DATE" in capsys.readouterr().out
 
 
+def test_check_skill_md_update_detected(monkeypatch, capsys):
+    """Update in SKILL.md (not scripts/) is detected."""
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "installed_at": "2025-06-01T00:00:00Z",
+        "skill_dir": ".claude/skills/video2pr",
+    }
+
+    def mock_fetch_json(url):
+        if "path=scripts" in url or "path=environment.yml" in url:
+            # scripts and environment.yml are old
+            return [{"commit": {"committer": {"date": "2025-01-01T00:00:00Z"}}}]
+        if "SKILL.md" in url:
+            # SKILL.md has a newer commit
+            return [{"commit": {"committer": {"date": "2025-12-01T00:00:00Z"}}}]
+        return []
+
+    monkeypatch.setattr(check_update, "fetch_json", mock_fetch_json)
+    result = check_update.check(config)
+    assert result is True
+    assert "UPDATE_AVAILABLE" in capsys.readouterr().out
+
+
 # ── Apply mode ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Add `find_conda()` to `check_deps.py` with Windows fallback paths (miniconda3/anaconda3 in `~` and `C:\ProgramData`), following the `_find_nvidia_smi()` pattern from `check_gpu.py`
- Print `CONDA_PATH: <path>` so SKILL.md agents can capture and use the resolved conda path for all subsequent commands
- Fix `check_update.py` to also check `environment.yml` and `SKILL.md` for updates, not just `scripts/`
- Update all three SKILL.md files (Claude Code, Codex, Copilot) with Phase 1 instructions to use the captured conda path

## Test plan

- [x] 7 new unit tests for `find_conda()` (which finds it, Windows fallbacks, non-Windows returns None)
- [x] 1 new test for SKILL.md update detection in `check_update.py`
- [x] Full test suite passes (70 tests)
- [x] `python scripts/check_deps.py` prints `CONDA_PATH:` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)