### PR TITLE
Fix skill to install GPU PyTorch directly instead of showing command

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -118,7 +118,7 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
 - Otherwise, continue silently.
 

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -119,7 +119,7 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
 - Otherwise, continue silently.
 

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -118,7 +118,7 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, show the install command, note the ~5-20x speedup, and **ask whether to install now or continue with CPU**. Wait for the user's response before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - If an update was flagged in Phase 0 (`UPDATE_AVAILABLE`): remind the user: "A video2pr update is available — you can update after this run with: `conda run -n video2pr python scripts/check_update.py --apply`"
 - Otherwise, continue silently.
 


### PR DESCRIPTION
## Summary
- Updated the pre-transcription GPU check in all three SKILL.md files (Claude, Codex, Copilot)
- The skill now runs the PyTorch install command itself (after user approval) instead of just displaying it for manual execution
- After installation, the skill re-runs `check_gpu.py` to confirm GPU support is active before proceeding

## Test plan
- [ ] Run the skill on a system with a GPU but without GPU-accelerated PyTorch
- [ ] Confirm the skill offers to install and, upon approval, runs the command itself
- [ ] Confirm it re-checks GPU status after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)