### PR TITLE
Fix skill behavioral issues: premature stop, self-reference, cached transcription

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -21,6 +21,7 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -77,6 +78,11 @@ Set up the output directory:
 # Use the video filename (without extension) as the subdirectory name
 mkdir -p .video2pr/<video-basename>
 ```
+
+**Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
+- If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
 **Check for external transcript:** Search for transcript files in the same directory as the video, matching the video basename with extensions: `.sbv`, `.vtt`, `.txt`, `.docx`. Also accept a user-provided transcript path. If found, report: "Found external transcript: meeting.vtt (MS Teams VTT format)"
 
@@ -161,6 +167,8 @@ Analyze the transcript to identify:
 3. **Action items** — tasks assigned to people, deadlines mentioned
 4. **Decisions** — conclusions reached, agreements made
 5. **Feature requests** — new features or changes discussed
+
+After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
 ## Phase 5: Codebase Analysis & Implementation Plan
 
@@ -248,7 +256,7 @@ Task 3 (independent)
 
 ### Step 5e: Present Plan for Review
 
-After writing `plan.md`, present the implementation plan to the user for review and confirmation before moving on to Phase 6 (summary generation). Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize.
+This is the ONLY user approval checkpoint before Phase 6. After writing `plan.md`, present the implementation plan for review. Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize before proceeding to Phase 6.
 
 ## Phase 6: Generate Summary
 

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -22,6 +22,7 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -78,6 +79,11 @@ Set up the output directory:
 # Use the video filename (without extension) as the subdirectory name
 mkdir -p .video2pr/<video-basename>
 ```
+
+**Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
+- If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
 **Check for external transcript:** Search for transcript files in the same directory as the video, matching the video basename with extensions: `.sbv`, `.vtt`, `.txt`, `.docx`. Also accept a user-provided transcript path. If found, report: "Found external transcript: meeting.vtt (MS Teams VTT format)"
 
@@ -162,6 +168,8 @@ Analyze the transcript to identify:
 3. **Action items** — tasks assigned to people, deadlines mentioned
 4. **Decisions** — conclusions reached, agreements made
 5. **Feature requests** — new features or changes discussed
+
+After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
 ## Phase 5: Codebase Analysis & Implementation Plan
 
@@ -249,7 +257,7 @@ Task 3 (independent)
 
 ### Step 5e: Enter Plan Mode
 
-After writing `plan.md`, use `EnterPlanMode` to present the implementation plan to the user for review. Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize before moving on to Phase 6 (summary generation). Use `ExitPlanMode` once the user confirms the plan.
+This is the ONLY user approval checkpoint before Phase 6. After writing `plan.md`, use `EnterPlanMode` to present the implementation plan for review. Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize. Use `ExitPlanMode` once the user confirms the plan, then proceed to Phase 6.
 
 ## Phase 6: Generate Summary
 

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -21,6 +21,7 @@ Process a meeting recording into a transcript, structured summary, and codebase-
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
 - The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -77,6 +78,11 @@ Set up the output directory:
 # Use the video filename (without extension) as the subdirectory name
 mkdir -p .video2pr/<video-basename>
 ```
+
+**Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
+- If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
 **Check for external transcript:** Search for transcript files in the same directory as the video, matching the video basename with extensions: `.sbv`, `.vtt`, `.txt`, `.docx`. Also accept a user-provided transcript path. If found, report: "Found external transcript: meeting.vtt (MS Teams VTT format)"
 
@@ -161,6 +167,8 @@ Analyze the transcript to identify:
 3. **Action items** — tasks assigned to people, deadlines mentioned
 4. **Decisions** — conclusions reached, agreements made
 5. **Feature requests** — new features or changes discussed
+
+After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
 ## Phase 5: Codebase Analysis & Implementation Plan
 
@@ -248,7 +256,7 @@ Task 3 (independent)
 
 ### Step 5e: Present Plan for Review
 
-After writing `plan.md`, present the implementation plan to the user for review and confirmation before moving on to Phase 6 (summary generation). Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize.
+This is the ONLY user approval checkpoint before Phase 6. After writing `plan.md`, present the implementation plan for review. Walk through the proposed tasks, highlight the top priorities, and let the user approve, adjust, or reprioritize before proceeding to Phase 6.
 
 ## Phase 6: Generate Summary
 


### PR DESCRIPTION
## Summary
- **Prevent premature stop**: Agent now completes all of Phase 5 (codebase scan + plan.md) before presenting the plan for approval, instead of stopping after Phase 4 transcript analysis
- **Ban self-referential output**: Added scope rule forbidding the agent from mentioning internal phase names, workflow mechanics, or skill internals in user-facing messages
- **Reuse cached transcription**: When `.video2pr/<basename>/transcript.json` or `audio.wav` already exist from a prior run, the skill detects them and offers to reuse instead of re-extracting/re-transcribing

## Test plan
- [ ] Run the skill on a video that has already been processed — verify it detects and offers to reuse existing `transcript.json`
- [ ] Run the skill on a new video — verify it proceeds from Phase 4 directly into Phase 5 without stopping for approval
- [ ] Check that user-facing output never mentions skill phases, workflow mechanics, or self-references
- [ ] Verify changes are consistent across all three SKILL.md variants (`.claude/`, `.agents/`, `.github/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)