### PR TITLE
Fix video2pr Windows skill packaging issues

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -17,11 +17,11 @@ allowed-tools: shell read_file apply_patch list_dir grep_files
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
-**Important — scope rules:**
+**Important - scope rules:**
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
-- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase - do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
-- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires...", "per Phase 5...", or "the workflow pauses here for...". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -32,7 +32,7 @@ conda run -n video2pr python scripts/check_update.py
 ```
 
 - If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
-- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly — do NOT just show the command for the user to run manually. Then continue to Phase 1.
+- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly - do NOT just show the command for the user to run manually. Then continue to Phase 1.
 
 ## Phase 1: Dependency Check
 
@@ -48,7 +48,6 @@ If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
 conda env create -f environment.yml
-conda activate video2pr
 ```
 
 After dependencies pass, check GPU status:
@@ -73,14 +72,10 @@ The user provides a video file path as the argument. Verify:
 conda run -n video2pr python scripts/get_duration.py --input "<video-path>"
 ```
 
-Set up the output directory:
-```bash
-# Use the video filename (without extension) as the subdirectory name
-mkdir -p .video2pr/<video-basename>
-```
+Set up the output directory by creating `.video2pr/<video-basename>/` if it does not already exist. Use the video filename (without extension) as the subdirectory name.
 
 **Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
-- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a-3d entirely and go to Phase 4.
 - If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
 - If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
@@ -93,30 +88,24 @@ mkdir -p .video2pr/<video-basename>
 Always extract audio (needed for language detection even with external transcripts):
 
 ```bash
-conda run -n video2pr python scripts/extract_audio.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>"
+conda run -n video2pr python scripts/extract_audio.py --input "<video-path>" --output-dir ".video2pr/<video-basename>"
 ```
 
 ### Phase 3b: Check for External Transcript
 
 If an external transcript was found in Phase 2:
 
-- **With timestamps** → Convert and skip Whisper, go to Phase 3d:
+- **With timestamps** -> Convert and skip Whisper, go to Phase 3d:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-- **Without timestamps** → Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
+- **Without timestamps** -> Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-If no external transcript → continue to Phase 3c.
+If no external transcript -> continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
 
@@ -124,14 +113,12 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) - do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --detect-language
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --detect-language
    ```
    Report: "Detected language: English (95% confidence)"
 
@@ -139,18 +126,14 @@ Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
 3. Run full transcription with the confirmed language:
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --output-dir ".video2pr/<video-basename>" \
-     --model small \
-     --language <confirmed-language-code>
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --output-dir ".video2pr/<video-basename>" --model small --language <confirmed-language-code>
    ```
 
 The default model is `small` (good balance of speed and accuracy). For faster but less accurate results use `--model base`; for higher accuracy (longer processing) use `--model medium` or `--model large`.
 
 ### Phase 3d: Speaker Enrichment (conditional)
 
-If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done directly (no script needed) — compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
+If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done directly (no script needed) - compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
 
 ## Phase 4: Analyze Transcript
 
@@ -163,10 +146,10 @@ When `speaker` fields are available, use them to attribute topics, action items,
 Analyze the transcript to identify:
 
 1. **Discussion topics** with timestamp ranges (start/end in HH:MM:SS)
-2. **Visual references** — phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
-3. **Action items** — tasks assigned to people, deadlines mentioned
-4. **Decisions** — conclusions reached, agreements made
-5. **Feature requests** — new features or changes discussed
+2. **Visual references** - phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
+3. **Action items** - tasks assigned to people, deadlines mentioned
+4. **Decisions** - conclusions reached, agreements made
+5. **Feature requests** - new features or changes discussed
 
 After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
@@ -177,13 +160,13 @@ This phase bridges the meeting discussion with the actual codebase, producing a 
 ### Step 5a: Extract Actionable Items
 
 From the Phase 4 analysis, extract every actionable item discussed. Categorize each as one of:
-- **requirement** — something that must be built or satisfied
-- **feature request** — a new capability or enhancement
-- **bug report** — a defect or unexpected behavior described
-- **refactoring** — restructuring existing code without changing behavior
-- **architecture change** — significant structural change to the system
-- **config change** — environment, deployment, or configuration update
-- **documentation** — docs, comments, or knowledge-base updates
+- **requirement** - something that must be built or satisfied
+- **feature request** - a new capability or enhancement
+- **bug report** - a defect or unexpected behavior described
+- **refactoring** - restructuring existing code without changing behavior
+- **architecture change** - significant structural change to the system
+- **config change** - environment, deployment, or configuration update
+- **documentation** - docs, comments, or knowledge-base updates
 
 For each item, record:
 - Title (concise)
@@ -195,10 +178,10 @@ For each item, record:
 
 For each actionable item, search the codebase **within the repository root** using file listing and content search tools — not the video file's directory. Classify each item:
 
-- **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
-- **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.
-- **New** — nothing relevant found. Confirm what was searched (patterns, directories) and not found.
-- **Not applicable** — the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
+- **Already exists** - the functionality or fix is already in place. Cite specific file paths and function/class names.
+- **Partially exists** - some relevant code exists but gaps remain. Cite existing code and describe what's missing.
+- **New** - nothing relevant found. Confirm what was searched (patterns, directories) and not found.
+- **Not applicable** - the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
 
 ### Step 5c: Build Implementation Plan
 
@@ -309,15 +292,12 @@ See [plan.md](plan.md) for the full implementation plan.
 
 **Do NOT extract frames at this stage.** Only include the ready-to-run commands.
 
-## Frame Extraction (utility — available anytime)
+## Frame Extraction (utility - available anytime)
 
 At any point during Phase 4, Phase 5, or later during implementation, you can extract a frame from the video when visual context would help understand what was discussed:
 
 ```bash
-conda run -n video2pr python scripts/extract_frame.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>" \
-  --timestamp HH:MM:SS
+conda run -n video2pr python scripts/extract_frame.py --input "<video-path>" --output-dir ".video2pr/<video-basename>" --timestamp HH:MM:SS
 ```
 
 The frame is saved to `.video2pr/<video-basename>/frames/frame_00h03m22s.png` and can be viewed directly.

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -18,11 +18,11 @@ allowed-tools:
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
-**Important — scope rules:**
+**Important - scope rules:**
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
-- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase - do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
-- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires...", "per Phase 5...", or "the workflow pauses here for...". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -33,7 +33,7 @@ conda run -n video2pr python scripts/check_update.py
 ```
 
 - If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
-- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly — do NOT just show the command for the user to run manually. Then continue to Phase 1.
+- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly - do NOT just show the command for the user to run manually. Then continue to Phase 1.
 
 ## Phase 1: Dependency Check
 
@@ -49,7 +49,6 @@ If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
 conda env create -f environment.yml
-conda activate video2pr
 ```
 
 After dependencies pass, check GPU status:
@@ -74,14 +73,10 @@ The user provides a video file path as the argument. Verify:
 conda run -n video2pr python scripts/get_duration.py --input "<video-path>"
 ```
 
-Set up the output directory:
-```bash
-# Use the video filename (without extension) as the subdirectory name
-mkdir -p .video2pr/<video-basename>
-```
+Set up the output directory by creating `.video2pr/<video-basename>/` if it does not already exist. Use the video filename (without extension) as the subdirectory name.
 
 **Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
-- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a-3d entirely and go to Phase 4.
 - If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
 - If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
@@ -94,30 +89,24 @@ mkdir -p .video2pr/<video-basename>
 Always extract audio (needed for language detection even with external transcripts):
 
 ```bash
-conda run -n video2pr python scripts/extract_audio.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>"
+conda run -n video2pr python scripts/extract_audio.py --input "<video-path>" --output-dir ".video2pr/<video-basename>"
 ```
 
 ### Phase 3b: Check for External Transcript
 
 If an external transcript was found in Phase 2:
 
-- **With timestamps** → Convert and skip Whisper, go to Phase 3d:
+- **With timestamps** -> Convert and skip Whisper, go to Phase 3d:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-- **Without timestamps** → Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
+- **Without timestamps** -> Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-If no external transcript → continue to Phase 3c.
+If no external transcript -> continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
 
@@ -125,14 +114,12 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) - do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --detect-language
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --detect-language
    ```
    Report: "Detected language: English (95% confidence)"
 
@@ -140,18 +127,14 @@ Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
 3. Run full transcription with the confirmed language:
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --output-dir ".video2pr/<video-basename>" \
-     --model small \
-     --language <confirmed-language-code>
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --output-dir ".video2pr/<video-basename>" --model small --language <confirmed-language-code>
    ```
 
 The default model is `small` (good balance of speed and accuracy). For faster but less accurate results use `--model base`; for higher accuracy (longer processing) use `--model medium` or `--model large`.
 
 ### Phase 3d: Speaker Enrichment (conditional)
 
-If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done by Claude directly (no script needed) — compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
+If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done by Claude directly (no script needed) - compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
 
 ## Phase 4: Analyze Transcript
 
@@ -164,10 +147,10 @@ When `speaker` fields are available, use them to attribute topics, action items,
 Analyze the transcript to identify:
 
 1. **Discussion topics** with timestamp ranges (start/end in HH:MM:SS)
-2. **Visual references** — phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
-3. **Action items** — tasks assigned to people, deadlines mentioned
-4. **Decisions** — conclusions reached, agreements made
-5. **Feature requests** — new features or changes discussed
+2. **Visual references** - phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
+3. **Action items** - tasks assigned to people, deadlines mentioned
+4. **Decisions** - conclusions reached, agreements made
+5. **Feature requests** - new features or changes discussed
 
 After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
@@ -178,13 +161,13 @@ This phase bridges the meeting discussion with the actual codebase, producing a 
 ### Step 5a: Extract Actionable Items
 
 From the Phase 4 analysis, extract every actionable item discussed. Categorize each as one of:
-- **requirement** — something that must be built or satisfied
-- **feature request** — a new capability or enhancement
-- **bug report** — a defect or unexpected behavior described
-- **refactoring** — restructuring existing code without changing behavior
-- **architecture change** — significant structural change to the system
-- **config change** — environment, deployment, or configuration update
-- **documentation** — docs, comments, or knowledge-base updates
+- **requirement** - something that must be built or satisfied
+- **feature request** - a new capability or enhancement
+- **bug report** - a defect or unexpected behavior described
+- **refactoring** - restructuring existing code without changing behavior
+- **architecture change** - significant structural change to the system
+- **config change** - environment, deployment, or configuration update
+- **documentation** - docs, comments, or knowledge-base updates
 
 For each item, record:
 - Title (concise)
@@ -196,10 +179,10 @@ For each item, record:
 
 For each actionable item, use Glob and Read to search the codebase **within the repository root** — not the video file's directory. Classify each item:
 
-- **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
-- **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.
-- **New** — nothing relevant found. Confirm what was searched (patterns, directories) and not found.
-- **Not applicable** — the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
+- **Already exists** - the functionality or fix is already in place. Cite specific file paths and function/class names.
+- **Partially exists** - some relevant code exists but gaps remain. Cite existing code and describe what's missing.
+- **New** - nothing relevant found. Confirm what was searched (patterns, directories) and not found.
+- **Not applicable** - the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
 
 ### Step 5c: Build Implementation Plan
 
@@ -310,15 +293,12 @@ See [plan.md](plan.md) for the full implementation plan.
 
 **Do NOT extract frames at this stage.** Only include the ready-to-run commands.
 
-## Frame Extraction (utility — available anytime)
+## Frame Extraction (utility - available anytime)
 
 At any point during Phase 4, Phase 5, or later during implementation, you can extract a frame from the video when visual context would help understand what was discussed:
 
 ```bash
-conda run -n video2pr python scripts/extract_frame.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>" \
-  --timestamp HH:MM:SS
+conda run -n video2pr python scripts/extract_frame.py --input "<video-path>" --output-dir ".video2pr/<video-basename>" --timestamp HH:MM:SS
 ```
 
 The frame is saved to `.video2pr/<video-basename>/frames/frame_00h03m22s.png` and can be viewed directly.

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -17,11 +17,11 @@ allowed-tools: Bash Read Write Glob
 
 Process a meeting recording into a transcript, structured summary, and codebase-grounded implementation plan.
 
-**Important — scope rules:**
+**Important - scope rules:**
 - The **codebase** is the repository root (the current working directory where this skill is invoked). All file scanning, analysis, and modifications must stay within this repository.
-- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase — do not scan, analyze, or modify files there.
+- The video file path is an **input artifact only**. Its parent directory is unrelated to the codebase - do not scan, analyze, or modify files there.
 - The only new directory created is `.video2pr/` inside the repo root for output files.
-- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires…", "per Phase 5…", or "the workflow pauses here for…". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
+- **Never reference this skill's internal workflow, phase names, or mechanics in user-facing output.** Do not say things like "the skill requires...", "per Phase 5...", or "the workflow pauses here for...". Communicate naturally about the work itself (e.g., "here's the implementation plan" not "Phase 5e requires plan approval").
 
 ## Phase 0: Check for Updates
 
@@ -32,7 +32,7 @@ conda run -n video2pr python scripts/check_update.py
 ```
 
 - If output contains `UP_TO_DATE` or `CHECK_SKIPPED`: continue to Phase 1 silently.
-- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly — do NOT just show the command for the user to run manually. Then continue to Phase 1.
+- If output contains `UPDATE_AVAILABLE`: display a **prominent warning** that a video2pr update is available and **ask whether to update now or continue with the current version**. Wait for the user's response. If they agree, run `conda run -n video2pr python scripts/check_update.py --apply` directly - do NOT just show the command for the user to run manually. Then continue to Phase 1.
 
 ## Phase 1: Dependency Check
 
@@ -48,7 +48,6 @@ If any dependencies show `MISSING:`, guide the user to install them:
 
 ```bash
 conda env create -f environment.yml
-conda activate video2pr
 ```
 
 After dependencies pass, check GPU status:
@@ -73,14 +72,10 @@ The user provides a video file path as the argument. Verify:
 conda run -n video2pr python scripts/get_duration.py --input "<video-path>"
 ```
 
-Set up the output directory:
-```bash
-# Use the video filename (without extension) as the subdirectory name
-mkdir -p .video2pr/<video-basename>
-```
+Set up the output directory by creating `.video2pr/<video-basename>/` if it does not already exist. Use the video filename (without extension) as the subdirectory name.
 
 **Check for existing outputs:** After creating the output directory, check whether prior runs already produced files in `.video2pr/<video-basename>/`:
-- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a–3d entirely and go to Phase 4.
+- If `transcript.json` exists: report "Found existing transcription from a previous run" and ask the user whether to reuse it or re-transcribe. If reusing, skip Phases 3a-3d entirely and go to Phase 4.
 - If `audio.wav` exists but `transcript.json` does not: report "Found previously extracted audio" and ask whether to reuse it. If reusing, skip Phase 3a.
 - If `plan.md` or `summary.md` exist: note their presence but always regenerate them (codebase may have changed).
 
@@ -93,30 +88,24 @@ mkdir -p .video2pr/<video-basename>
 Always extract audio (needed for language detection even with external transcripts):
 
 ```bash
-conda run -n video2pr python scripts/extract_audio.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>"
+conda run -n video2pr python scripts/extract_audio.py --input "<video-path>" --output-dir ".video2pr/<video-basename>"
 ```
 
 ### Phase 3b: Check for External Transcript
 
 If an external transcript was found in Phase 2:
 
-- **With timestamps** → Convert and skip Whisper, go to Phase 3d:
+- **With timestamps** -> Convert and skip Whisper, go to Phase 3d:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-- **Without timestamps** → Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
+- **Without timestamps** -> Convert to get speaker info, then continue to Phase 3c for Whisper transcription:
   ```bash
-  conda run -n video2pr python scripts/convert_transcript.py \
-    --input "<transcript-path>" \
-    --output-dir ".video2pr/<video-basename>"
+  conda run -n video2pr python scripts/convert_transcript.py --input "<transcript-path>" --output-dir ".video2pr/<video-basename>"
   ```
 
-If no external transcript → continue to Phase 3c.
+If no external transcript -> continue to Phase 3c.
 
 ### Phase 3c: Language Detection + Whisper Transcription
 
@@ -124,14 +113,12 @@ If no external transcript → continue to Phase 3c.
 
 Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
-- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
+- If `torch_device_available` is `false` AND `install_command` is not null: display a **prominent warning** to the user explaining that their GPU is available but not being used, note the ~5-20x speedup, and **ask whether to install GPU-accelerated PyTorch now or continue with CPU**. Wait for the user's response. If they agree, run the install command directly (e.g., `conda run -n video2pr <install_command>`) - do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU support is active before proceeding.
 - Otherwise, continue silently.
 
 1. Detect language (always uses base model for speed):
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --detect-language
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --detect-language
    ```
    Report: "Detected language: English (95% confidence)"
 
@@ -139,18 +126,14 @@ Run GPU check: `conda run -n video2pr python scripts/check_gpu.py`
 
 3. Run full transcription with the confirmed language:
    ```bash
-   conda run -n video2pr python scripts/transcribe.py \
-     --input ".video2pr/<video-basename>/audio.wav" \
-     --output-dir ".video2pr/<video-basename>" \
-     --model small \
-     --language <confirmed-language-code>
+   conda run -n video2pr python scripts/transcribe.py --input ".video2pr/<video-basename>/audio.wav" --output-dir ".video2pr/<video-basename>" --model small --language <confirmed-language-code>
    ```
 
 The default model is `small` (good balance of speed and accuracy). For faster but less accurate results use `--model base`; for higher accuracy (longer processing) use `--model medium` or `--model large`.
 
 ### Phase 3d: Speaker Enrichment (conditional)
 
-If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done directly (no script needed) — compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
+If an external transcript WITHOUT timestamps was used AND Whisper ran in Phase 3c: match text between the Whisper output and the external transcript to add `speaker` fields to the Whisper segments. This is done directly (no script needed) - compare overlapping text to attribute speakers from the external transcript to Whisper's timestamped segments.
 
 ## Phase 4: Analyze Transcript
 
@@ -163,10 +146,10 @@ When `speaker` fields are available, use them to attribute topics, action items,
 Analyze the transcript to identify:
 
 1. **Discussion topics** with timestamp ranges (start/end in HH:MM:SS)
-2. **Visual references** — phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
-3. **Action items** — tasks assigned to people, deadlines mentioned
-4. **Decisions** — conclusions reached, agreements made
-5. **Feature requests** — new features or changes discussed
+2. **Visual references** - phrases like "as you can see", "this slide shows", "let me show you", "on the screen", "this diagram", etc. Use the word-level `start` time to get precise timestamps for frame extraction.
+3. **Action items** - tasks assigned to people, deadlines mentioned
+4. **Decisions** - conclusions reached, agreements made
+5. **Feature requests** - new features or changes discussed
 
 After completing this analysis, proceed directly to Phase 5. Do NOT ask for user approval or enter plan mode at this stage — the plan review checkpoint comes after the codebase analysis in Phase 5.
 
@@ -177,13 +160,13 @@ This phase bridges the meeting discussion with the actual codebase, producing a 
 ### Step 5a: Extract Actionable Items
 
 From the Phase 4 analysis, extract every actionable item discussed. Categorize each as one of:
-- **requirement** — something that must be built or satisfied
-- **feature request** — a new capability or enhancement
-- **bug report** — a defect or unexpected behavior described
-- **refactoring** — restructuring existing code without changing behavior
-- **architecture change** — significant structural change to the system
-- **config change** — environment, deployment, or configuration update
-- **documentation** — docs, comments, or knowledge-base updates
+- **requirement** - something that must be built or satisfied
+- **feature request** - a new capability or enhancement
+- **bug report** - a defect or unexpected behavior described
+- **refactoring** - restructuring existing code without changing behavior
+- **architecture change** - significant structural change to the system
+- **config change** - environment, deployment, or configuration update
+- **documentation** - docs, comments, or knowledge-base updates
 
 For each item, record:
 - Title (concise)
@@ -195,10 +178,10 @@ For each item, record:
 
 For each actionable item, search the codebase **within the repository root** using file listing and content search tools — not the video file's directory. Classify each item:
 
-- **Already exists** — the functionality or fix is already in place. Cite specific file paths and function/class names.
-- **Partially exists** — some relevant code exists but gaps remain. Cite existing code and describe what's missing.
-- **New** — nothing relevant found. Confirm what was searched (patterns, directories) and not found.
-- **Not applicable** — the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
+- **Already exists** - the functionality or fix is already in place. Cite specific file paths and function/class names.
+- **Partially exists** - some relevant code exists but gaps remain. Cite existing code and describe what's missing.
+- **New** - nothing relevant found. Confirm what was searched (patterns, directories) and not found.
+- **Not applicable** - the item doesn't apply to this codebase (e.g., refers to an external system). Explain why.
 
 ### Step 5c: Build Implementation Plan
 
@@ -309,15 +292,12 @@ See [plan.md](plan.md) for the full implementation plan.
 
 **Do NOT extract frames at this stage.** Only include the ready-to-run commands.
 
-## Frame Extraction (utility — available anytime)
+## Frame Extraction (utility - available anytime)
 
 At any point during Phase 4, Phase 5, or later during implementation, you can extract a frame from the video when visual context would help understand what was discussed:
 
 ```bash
-conda run -n video2pr python scripts/extract_frame.py \
-  --input "<video-path>" \
-  --output-dir ".video2pr/<video-basename>" \
-  --timestamp HH:MM:SS
+conda run -n video2pr python scripts/extract_frame.py --input "<video-path>" --output-dir ".video2pr/<video-basename>" --timestamp HH:MM:SS
 ```
 
 The frame is saved to `.video2pr/<video-basename>/frames/frame_00h03m22s.png` and can be viewed directly.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # video2PR
 
-An AI coding assistant skill that converts meeting video recordings into structured context — transcripts with timestamps, speaker attribution, action items, decisions, and a codebase-grounded implementation plan. Works with Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI.
+An AI coding assistant skill that converts meeting video recordings into structured context - transcripts with timestamps, speaker attribution, action items, decisions, and a codebase-grounded implementation plan. Works with Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI.
 
 ## Cross-Platform Support
 
@@ -12,7 +12,7 @@ video2PR works with multiple AI coding assistants:
 | [OpenAI Codex CLI](https://github.com/openai/codex) | `.agents/skills/video2pr/` | Full support |
 | [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli) | `.github/skills/video2pr/` | Full support |
 
-Each skill folder is fully self-contained — SKILL.md, scripts, and environment.yml are all included.
+Each skill folder is fully self-contained - SKILL.md, scripts, and environment.yml are all included.
 
 ## Getting Started
 
@@ -37,33 +37,27 @@ python /path/to/video2PR/install_video2pr.py /path/to/your-project --assistants 
 python /path/to/video2PR/install_video2pr.py /path/to/your-project --dry-run
 ```
 
-Each skill folder is fully self-contained — scripts and environment.yml are copied alongside the SKILL.md. No files are placed outside the skill folder.
+Each skill folder is fully self-contained - scripts and environment.yml are copied alongside the SKILL.md. No files are placed outside the skill folder.
 
 ### Updating
 
-The skill checks for updates on each run and notifies you if a newer version is available. To apply:
+The skill checks for updates on each run and notifies you if a newer version is available. To apply, run the updater from the skill directory you installed:
 
 ```bash
 conda run -n video2pr python .claude/skills/video2pr/scripts/check_update.py --apply
+conda run -n video2pr python .agents/skills/video2pr/scripts/check_update.py --apply
+conda run -n video2pr python .github/skills/video2pr/scripts/check_update.py --apply
 ```
 
 <details>
 <summary>Manual installation</summary>
 
-```bash
-# Copy the skill folder for your platform into your project:
+Manual install is a folder copy, and the source/destination paths are the same on Windows, macOS, and Linux:
 
-# Claude Code
-cp -r .claude/skills/video2pr /path/to/your-project/.claude/skills/
-
-# Codex CLI
-cp -r .agents/skills/video2pr /path/to/your-project/.agents/skills/
-
-# Copilot CLI
-cp -r .github/skills/video2pr /path/to/your-project/.github/skills/
-mkdir -p /path/to/your-project/.github/agents
-cp .github/agents/video2pr.agent.md /path/to/your-project/.github/agents/
-```
+- Claude Code: copy `.claude/skills/video2pr/` into `<project>/.claude/skills/video2pr/`
+- Codex CLI: copy `.agents/skills/video2pr/` into `<project>/.agents/skills/video2pr/`
+- GitHub Copilot CLI: copy `.github/skills/video2pr/` into `<project>/.github/skills/video2pr/`
+- GitHub Copilot CLI: also copy `.github/agents/video2pr.agent.md` into `<project>/.github/agents/video2pr.agent.md`
 
 </details>
 
@@ -80,7 +74,7 @@ Output goes to `.video2pr/<video-name>/` (add `.video2pr/` to your `.gitignore`)
 ## What It Does
 
 1. Extracts audio from video (mp4, mkv, avi, mov, webm)
-2. Detects spoken language with confidence scoring — asks for confirmation if < 80%
+2. Detects spoken language with confidence scoring - asks for confirmation if < 80%
 3. Transcribes via Whisper with word-level timestamps, or imports an external transcript (Google Meet SBV/TXT, MS Teams VTT/DOCX) with speaker attribution
 4. Analyzes the codebase against what was discussed and produces a concrete implementation plan (`plan.md`)
 5. Produces `summary.md` with topics, action items, decisions, visual reference commands, and a link to the implementation plan
@@ -94,7 +88,7 @@ The `--model` flag controls the quality/speed tradeoff for transcription:
 | Model | Parameters | Relative Speed | Best For |
 |-------|-----------|----------------|----------|
 | `base` | 74M | ~10x realtime | Quick drafts, testing, short meetings |
-| `small` | 244M | ~4x realtime | **Default** — good balance of speed and accuracy |
+| `small` | 244M | ~4x realtime | **Default** - good balance of speed and accuracy |
 | `medium` | 769M | ~1.5x realtime | Important meetings where accuracy matters |
 | `large` | 1550M | ~0.5x realtime | Maximum accuracy, multilingual content |
 
@@ -104,16 +98,13 @@ Speed estimates assume GPU acceleration. CPU-only runs are roughly 5-20x slower.
 
 ```bash
 # Detect language
-conda run -n video2pr python scripts/transcribe.py \
-  --input audio.wav --detect-language
+conda run -n video2pr python scripts/transcribe.py --input audio.wav --detect-language
 
 # Transcribe with explicit language
-conda run -n video2pr python scripts/transcribe.py \
-  --input audio.wav --output-dir out --model small --language en
+conda run -n video2pr python scripts/transcribe.py --input audio.wav --output-dir out --model small --language en
 
 # Convert an external transcript
-conda run -n video2pr python scripts/convert_transcript.py \
-  --input meeting.vtt --output-dir out
+conda run -n video2pr python scripts/convert_transcript.py --input meeting.vtt --output-dir out
 ```
 
 ## Output Files

--- a/install_video2pr.py
+++ b/install_video2pr.py
@@ -122,12 +122,12 @@ def install_assistant(target: Path, name: str, dry_run: bool) -> list[str]:
     # Copy and rewrite SKILL.md
     src = REPO_ROOT / cfg["skill_md"]
     dst = dest / "SKILL.md"
-    content = src.read_text()
+    content = src.read_text(encoding="utf-8")
     content = rewrite_paths(content, skill_dir)
     if dry_run:
         print(f"  copy+rewrite {cfg['skill_md']} -> {dst.relative_to(target)}")
     else:
-        dst.write_text(content)
+        dst.write_text(content, encoding="utf-8")
     installed.append("SKILL.md")
 
     # Copy extra files within skill dir (e.g., openai.yaml)
@@ -164,7 +164,7 @@ def install_assistant(target: Path, name: str, dry_run: bool) -> list[str]:
     if dry_run:
         print(f"  write {config_path.relative_to(target)}")
     else:
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2)
             f.write("\n")
     installed.append(".video2pr_install.json")

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -19,6 +19,39 @@ CLI_TOOLS = ["ffmpeg", "ffprobe", "whisper"]
 PYTHON_IMPORTS = {"python-docx": "docx"}
 
 
+def parse_json_output(output: str):
+    """Extract a JSON value from mixed stdout/stderr style output.
+
+    Some `conda run` invocations on Windows emit extra banner or status lines
+    before/after the actual JSON payload. Prefer whole-line JSON first, then
+    fall back to scanning for the first decodable object/array in the text.
+    """
+    decoder = json.JSONDecoder()
+
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            value, end = decoder.raw_decode(line)
+        except json.JSONDecodeError:
+            continue
+        if line[end:].strip():
+            continue
+        return value
+
+    for idx, char in enumerate(output):
+        if char not in "{[":
+            continue
+        try:
+            value, _ = decoder.raw_decode(output[idx:])
+        except json.JSONDecodeError:
+            continue
+        return value
+
+    return None
+
+
 def find_conda():
     """Find the conda executable path, with Windows fallback.
 
@@ -78,7 +111,10 @@ def env_exists(env_name, conda_path="conda"):
     )
     if result.returncode != 0:
         return False
-    envs = json.loads(result.stdout).get("envs", [])
+    payload = parse_json_output(result.stdout)
+    if not isinstance(payload, dict):
+        return False
+    envs = payload.get("envs", [])
     return any(Path(e).name == env_name for e in envs)
 
 
@@ -108,8 +144,12 @@ def check_deps_in_env(conda_path="conda"):
         # Fallback: report everything as missing
         all_names = CLI_TOOLS + list(PYTHON_IMPORTS.keys())
         return {name: False for name in all_names}
+    payload = parse_json_output(result.stdout)
+    if isinstance(payload, dict):
+        return payload
 
-    return json.loads(result.stdout)
+    all_names = CLI_TOOLS + list(PYTHON_IMPORTS.keys())
+    return {name: False for name in all_names}
 
 
 def main():
@@ -158,8 +198,10 @@ def main():
             text=True,
         )
         if gpu_result.returncode == 0:
+            gpu_info = parse_json_output(gpu_result.stdout)
             try:
-                gpu_info = json.loads(gpu_result.stdout)
+                if not isinstance(gpu_info, dict):
+                    raise ValueError("missing JSON payload")
                 device = gpu_info.get("device", "cpu")
                 gpu_name = gpu_info.get("gpu_name")
                 cuda_version = gpu_info.get("cuda_version")
@@ -177,7 +219,7 @@ def main():
                         print(f"    {install_cmd}")
                 else:
                     print("  GPU: CPU only")
-            except (json.JSONDecodeError, KeyError):
+            except (ValueError, KeyError):
                 print("  GPU: detection failed")
 
 

--- a/scripts/check_update.py
+++ b/scripts/check_update.py
@@ -14,6 +14,7 @@ GITHUB_RAW = "https://raw.githubusercontent.com/{repo}/{branch}/{path}"
 
 SCRIPT_NAMES = [
     "check_deps.py",
+    "check_gpu.py",
     "check_update.py",
     "convert_transcript.py",
     "extract_audio.py",
@@ -36,7 +37,7 @@ def load_config(script_dir: Path) -> dict:
     if not config_path.exists():
         print("CHECK_SKIPPED: No .video2pr_install.json found", file=sys.stderr)
         sys.exit(0)
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -44,14 +45,14 @@ def fetch_json(url: str) -> dict:
     """Fetch JSON from a URL."""
     req = urllib.request.Request(url, headers={"User-Agent": "video2pr-updater"})
     with urllib.request.urlopen(req, timeout=10) as resp:
-        return json.loads(resp.read().decode())
+        return json.loads(resp.read().decode("utf-8"))
 
 
 def fetch_text(url: str) -> str:
     """Fetch text content from a URL."""
     req = urllib.request.Request(url, headers={"User-Agent": "video2pr-updater"})
     with urllib.request.urlopen(req, timeout=10) as resp:
-        return resp.read().decode()
+        return resp.read().decode("utf-8")
 
 
 def check(config: dict) -> bool:
@@ -104,7 +105,7 @@ def apply_update(config: dict, script_dir: Path) -> None:
         try:
             content = fetch_text(url)
             dest = script_dir / name
-            dest.write_text(content)
+            dest.write_text(content, encoding="utf-8")
             updated.append(f"scripts/{name}")
         except urllib.error.HTTPError as e:
             print(f"  Warning: could not download {name}: {e}", file=sys.stderr)
@@ -113,7 +114,7 @@ def apply_update(config: dict, script_dir: Path) -> None:
     url = GITHUB_RAW.format(repo=repo, branch=branch, path="environment.yml")
     try:
         content = fetch_text(url)
-        (base_dir / "environment.yml").write_text(content)
+        (base_dir / "environment.yml").write_text(content, encoding="utf-8")
         updated.append("environment.yml")
     except urllib.error.HTTPError as e:
         print(f"  Warning: could not download environment.yml: {e}", file=sys.stderr)
@@ -125,7 +126,7 @@ def apply_update(config: dict, script_dir: Path) -> None:
         try:
             content = fetch_text(url)
             content = rewrite_paths(content, skill_dir)
-            (base_dir / "SKILL.md").write_text(content)
+            (base_dir / "SKILL.md").write_text(content, encoding="utf-8")
             updated.append("SKILL.md")
         except urllib.error.HTTPError as e:
             print(f"  Warning: could not download SKILL.md: {e}", file=sys.stderr)
@@ -133,7 +134,7 @@ def apply_update(config: dict, script_dir: Path) -> None:
     # Update installed_at in config
     config["installed_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     config_path = base_dir / ".video2pr_install.json"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)
         f.write("\n")
 

--- a/scripts/convert_transcript.py
+++ b/scripts/convert_transcript.py
@@ -281,7 +281,10 @@ def convert(input_path: Path, output_dir: Path, fmt: str) -> None:
     # Write canonical transcript.json
     transcript = {"segments": segments}
     transcript_path = output_dir / "transcript.json"
-    transcript_path.write_text(json.dumps(transcript, indent=2, ensure_ascii=False))
+    transcript_path.write_text(
+        json.dumps(transcript, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
     print(f"Transcript saved to {transcript_path}")
 
     # Write metadata
@@ -299,7 +302,10 @@ def convert(input_path: Path, output_dir: Path, fmt: str) -> None:
         "segment_count": len(segments),
     }
     meta_path = output_dir / "external_transcript_meta.json"
-    meta_path.write_text(json.dumps(meta, indent=2, ensure_ascii=False))
+    meta_path.write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
     print(f"Metadata saved to {meta_path}")
 
     # Copy original file

--- a/scripts/extract_audio.py
+++ b/scripts/extract_audio.py
@@ -70,7 +70,7 @@ def main():
     print(f"Extracting metadata from {input_path.name}...")
     metadata = get_metadata(input_path)
     metadata_path = output_dir / "metadata.json"
-    metadata_path.write_text(json.dumps(metadata, indent=2))
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
     print(f"Metadata saved to {metadata_path}")
 
     # Extract audio

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -287,7 +287,7 @@ def transcribe_chunked(
             # Read chunk SRT for merging (writer already wrote it)
             chunk_srt_path = chunk_out / f"{chunk_path.stem}.srt"
             if chunk_srt_path.exists():
-                chunk_srt = chunk_srt_path.read_text()
+                chunk_srt = chunk_srt_path.read_text(encoding="utf-8")
                 offset_text, srt_index = offset_srt(chunk_srt, offset, srt_index)
                 srt_parts.append(offset_text)
 
@@ -295,12 +295,15 @@ def transcribe_chunked(
 
         # Write merged outputs
         srt_path = output_dir / "transcript.srt"
-        srt_path.write_text("\n".join(srt_parts).strip() + "\n")
+        srt_path.write_text("\n".join(srt_parts).strip() + "\n", encoding="utf-8")
         print(f"Merged SRT saved to {srt_path}")
 
         json_path = output_dir / "transcript.json"
         merged = {"segments": all_segments}
-        json_path.write_text(json.dumps(merged, indent=2, ensure_ascii=False))
+        json_path.write_text(
+            json.dumps(merged, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
         print(f"Merged JSON saved to {json_path}")
 
         ratio = duration / total_elapsed if total_elapsed > 0 else 0

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,7 +1,8 @@
-"""Tests for scripts/check_deps.py — conda path discovery."""
+"""Tests for scripts/check_deps.py - conda path discovery and JSON parsing."""
 
 import sys
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import pytest
@@ -86,3 +87,76 @@ class TestFindConda:
         ):
             result = check_deps.find_conda()
         assert result is None
+
+
+def test_parse_json_output_accepts_banner_wrapped_json():
+    output = 'banner line\n{"ffmpeg": true, "ffprobe": true}\ntrailer line\n'
+    assert check_deps.parse_json_output(output) == {
+        "ffmpeg": True,
+        "ffprobe": True,
+    }
+
+
+def test_check_deps_in_env_accepts_noisy_stdout():
+    stdout = (
+        "Preparing transaction...\n"
+        '{"ffmpeg": true, "ffprobe": true, "whisper": true, "python-docx": true}\n'
+        "done\n"
+    )
+    with patch(
+        "check_deps.subprocess.run",
+        return_value=CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=""),
+    ):
+        result = check_deps.check_deps_in_env("conda")
+
+    assert result == {
+        "ffmpeg": True,
+        "ffprobe": True,
+        "whisper": True,
+        "python-docx": True,
+    }
+
+
+def test_check_deps_in_env_falls_back_when_json_missing():
+    with patch(
+        "check_deps.subprocess.run",
+        return_value=CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="banner only\nstill no json\n",
+            stderr="",
+        ),
+    ):
+        result = check_deps.check_deps_in_env("conda")
+
+    assert result == {
+        "ffmpeg": False,
+        "ffprobe": False,
+        "whisper": False,
+        "python-docx": False,
+    }
+
+
+def test_main_parses_gpu_json_with_banner(capsys):
+    gpu_stdout = (
+        "preparing...\n"
+        '{"device": "cuda", "gpu_name": "RTX 4090", "cuda_version": "12.4", '
+        '"torch_device_available": true, "install_command": null}\n'
+    )
+    deps = {"ffmpeg": True, "ffprobe": True, "whisper": True, "python-docx": True}
+
+    with (
+        patch("check_deps.find_conda", return_value="conda"),
+        patch("check_deps.env_exists", return_value=True),
+        patch("check_deps.check_deps_in_env", return_value=deps),
+        patch(
+            "check_deps.subprocess.run",
+            return_value=CompletedProcess(
+                args=[], returncode=0, stdout=gpu_stdout, stderr=""
+            ),
+        ),
+    ):
+        check_deps.main()
+
+    out = capsys.readouterr().out
+    assert "GPU: RTX 4090 (CUDA 12.4) — OK" in out

--- a/tests/test_check_update.py
+++ b/tests/test_check_update.py
@@ -146,6 +146,59 @@ def test_apply_downloads_and_rewrites(tmp_path, monkeypatch, capsys):
     assert "UPDATED" in capsys.readouterr().out
 
 
+def test_apply_downloads_and_rewrites_codex(tmp_path, monkeypatch):
+    skill_dir = tmp_path / ".agents" / "skills" / "video2pr"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "skill_dir": ".agents/skills/video2pr",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config), encoding="utf-8")
+
+    def mock_fetch_text(url):
+        if "SKILL.md" in url:
+            return "Run scripts/check_deps.py and environment.yml in Português"
+        return f"# content for {url.split('/')[-1]}"
+
+    monkeypatch.setattr(check_update, "fetch_text", mock_fetch_text)
+    check_update.apply_update(config, scripts_dir)
+
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert ".agents/skills/video2pr/scripts/" in skill_md
+    assert ".agents/skills/video2pr/environment.yml" in skill_md
+    assert "Português" in skill_md
+
+
+def test_apply_downloads_and_rewrites_copilot(tmp_path, monkeypatch):
+    skill_dir = tmp_path / ".github" / "skills" / "video2pr"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    config = {
+        "repo": "test/repo",
+        "branch": "main",
+        "skill_dir": ".github/skills/video2pr",
+        "installed_at": "2025-01-01T00:00:00Z",
+    }
+    (skill_dir / ".video2pr_install.json").write_text(json.dumps(config), encoding="utf-8")
+
+    def mock_fetch_text(url):
+        if "SKILL.md" in url:
+            return "Run scripts/check_deps.py and environment.yml"
+        return f"# content for {url.split('/')[-1]}"
+
+    monkeypatch.setattr(check_update, "fetch_text", mock_fetch_text)
+    check_update.apply_update(config, scripts_dir)
+
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert ".github/skills/video2pr/scripts/" in skill_md
+    assert ".github/skills/video2pr/environment.yml" in skill_md
+
+
 def test_apply_handles_http_error(tmp_path, monkeypatch, capsys):
     """One download raises HTTPError, others succeed, no crash."""
     skill_dir = tmp_path / ".claude" / "skills" / "video2pr"

--- a/tests/test_convert_transcript.py
+++ b/tests/test_convert_transcript.py
@@ -1,5 +1,7 @@
 """Tests for scripts/convert_transcript.py."""
 
+import json
+
 import pytest
 
 from conftest import import_script
@@ -122,3 +124,20 @@ def test_detect_format_by_extension(tmp_path):
     vtt = tmp_path / "test.vtt"
     vtt.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:05.000\ntext")
     assert ct.detect_format(vtt) == "vtt"
+
+
+def test_convert_writes_utf8_json(tmp_path):
+    transcript = tmp_path / "meeting.txt"
+    transcript.write_text("José (0:00:01)\nnegócio e migração", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    ct.convert(transcript, output_dir, "google_txt")
+
+    transcript_json = json.loads((output_dir / "transcript.json").read_text(encoding="utf-8"))
+    meta_json = json.loads(
+        (output_dir / "external_transcript_meta.json").read_text(encoding="utf-8")
+    )
+
+    assert transcript_json["segments"][0]["speaker"] == "José"
+    assert transcript_json["segments"][0]["text"] == "negócio e migração"
+    assert meta_json["original_file"] == "meeting.txt"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -32,6 +32,24 @@ def test_rewrite_paths_no_match():
     assert install.rewrite_paths(text, ".claude/skills/video2pr") == text
 
 
+def test_rewrite_paths_codex():
+    result = install.rewrite_paths(
+        "python scripts/check_deps.py\nconda env create -f environment.yml",
+        ".agents/skills/video2pr",
+    )
+    assert "python .agents/skills/video2pr/scripts/check_deps.py" in result
+    assert "conda env create -f .agents/skills/video2pr/environment.yml" in result
+
+
+def test_rewrite_paths_copilot():
+    result = install.rewrite_paths(
+        "python scripts/check_deps.py\nconda env create -f environment.yml",
+        ".github/skills/video2pr",
+    )
+    assert "python .github/skills/video2pr/scripts/check_deps.py" in result
+    assert "conda env create -f .github/skills/video2pr/environment.yml" in result
+
+
 # ── Source validation ───────────────────────────────────────────────
 
 
@@ -108,15 +126,37 @@ def test_install_claude_code(fake_repo, target_dir, monkeypatch):
 def test_install_codex_has_openai_yaml(fake_repo, target_dir, monkeypatch):
     monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
     install.install_assistant(target_dir, "codex", dry_run=False)
-    assert (
-        target_dir / ".agents" / "skills" / "video2pr" / "agents" / "openai.yaml"
-    ).exists()
+    skill_dir = target_dir / ".agents" / "skills" / "video2pr"
+    assert (skill_dir / "agents" / "openai.yaml").exists()
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert ".agents/skills/video2pr/scripts/" in skill_md
+    assert ".agents/skills/video2pr/environment.yml" in skill_md
 
 
 def test_install_copilot_has_agent_md(fake_repo, target_dir, monkeypatch):
     monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
     install.install_assistant(target_dir, "copilot", dry_run=False)
+    skill_dir = target_dir / ".github" / "skills" / "video2pr"
     assert (target_dir / ".github" / "agents" / "video2pr.agent.md").exists()
+    skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert ".github/skills/video2pr/scripts/" in skill_md
+    assert ".github/skills/video2pr/environment.yml" in skill_md
+
+
+def test_install_preserves_utf8_skill_text(fake_repo, target_dir, monkeypatch):
+    monkeypatch.setattr(install, "REPO_ROOT", fake_repo)
+    skill_src = fake_repo / ".agents" / "skills" / "video2pr" / "SKILL.md"
+    skill_src.write_text(
+        "---\nname: video2pr\n---\n\nPortuguês: negócio e migração.\n",
+        encoding="utf-8",
+    )
+
+    install.install_assistant(target_dir, "codex", dry_run=False)
+
+    installed = (
+        target_dir / ".agents" / "skills" / "video2pr" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "Português: negócio e migração." in installed
 
 
 # ── Dry run ─────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary
- harden `check_deps.py` against noisy `conda run` JSON output on Windows
- make install/update and transcript artifact writes use explicit UTF-8
- fix assistant-specific skill path rewriting and update coverage for Codex/Copilot
- normalize skill and README command examples to be more cross-platform

## Validation
- `pytest tests/test_check_deps.py tests/test_install.py tests/test_check_update.py tests/test_convert_transcript.py tests/test_transcribe.py -q`
- `python scripts/check_deps.py`
