### PR TITLE
Fix check_deps empty-stdout failure on Windows via conda.bat

### DIFF
--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -6,6 +6,7 @@ CLI tools and Python packages are available *inside* that environment.
 This script itself runs from system Python — no conda activation needed.
 """
 
+import contextlib
 import json
 import os
 import platform
@@ -154,10 +155,8 @@ def check_deps_in_env(conda_path="conda"):
             text=True,
         )
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(tmp_path)
-        except OSError:
-            pass
     if result.returncode != 0:
         # Fallback: report everything as missing
         all_names = CLI_TOOLS + list(PYTHON_IMPORTS.keys())

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -7,10 +7,12 @@ This script itself runs from system Python — no conda activation needed.
 """
 
 import json
+import os
 import platform
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ENV_NAME = "video2pr"
@@ -138,11 +140,24 @@ def check_deps_in_env(conda_path="conda"):
         "import shutil, json\nresults = {}\n" + "\n".join(checks) + "\nprint(json.dumps(results))"
     )
 
-    result = subprocess.run(
-        [conda_path, "run", "-n", ENV_NAME, "python", "-c", script],
-        capture_output=True,
-        text=True,
-    )
+    # Write the script to a temp .py file rather than passing it via `python -c`.
+    # On Windows, conda is a .bat wrapper invoked through cmd.exe, which mangles
+    # arguments containing newlines — a multi-line `-c` script silently produces
+    # empty stdout in that path, making every dep look missing.
+    fd, tmp_path = tempfile.mkstemp(suffix=".py")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(script)
+        result = subprocess.run(
+            [conda_path, "run", "-n", ENV_NAME, "python", tmp_path],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
     if result.returncode != 0:
         # Fallback: report everything as missing
         all_names = CLI_TOOLS + list(PYTHON_IMPORTS.keys())

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -311,9 +311,11 @@ def test_check_deps_in_env_cleans_up_temp_file_on_subprocess_error():
         captured["tmp_path"] = args[-1]
         raise OSError("simulated subprocess failure")
 
-    with patch("check_deps.subprocess.run", side_effect=fake_run):
-        with pytest.raises(OSError):
-            check_deps.check_deps_in_env("conda")
+    with (
+        patch("check_deps.subprocess.run", side_effect=fake_run),
+        pytest.raises(OSError),
+    ):
+        check_deps.check_deps_in_env("conda")
 
     assert not os.path.exists(captured["tmp_path"]), (
         f"temp script file {captured['tmp_path']!r} was not cleaned up after error"

--- a/tests/test_check_deps.py
+++ b/tests/test_check_deps.py
@@ -1,5 +1,6 @@
 """Tests for scripts/check_deps.py - conda path discovery and JSON parsing."""
 
+import os
 import sys
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -255,6 +256,68 @@ def test_check_deps_in_env_falls_back_when_json_missing():
         "faster-whisper": False,
         "python-docx": False,
     }
+
+
+def test_check_deps_in_env_uses_temp_file_not_dash_c():
+    """Regression: the conda invocation must pass a script *file* path, not
+    a multi-line `-c <script>` argument. On Windows, conda is a .bat wrapper
+    invoked via cmd.exe, which mangles newline-bearing arguments and silently
+    produces empty stdout — making every dep look missing."""
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = list(args)
+        captured["script_existed_during_call"] = os.path.exists(args[-1])
+        return CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout='{"ffmpeg": true, "ffprobe": true,'
+            ' "faster-whisper": true, "python-docx": true}\n',
+            stderr="",
+        )
+
+    with patch("check_deps.subprocess.run", side_effect=fake_run):
+        check_deps.check_deps_in_env("conda")
+
+    args = captured["args"]
+    assert "-c" not in args, f"check_deps_in_env must not pass `-c <script>`; got {args}"
+    assert args[-1].endswith(".py"), f"expected a .py temp file path, got {args[-1]!r}"
+    assert captured["script_existed_during_call"], (
+        "the temp script file must exist on disk while subprocess.run is invoked"
+    )
+
+
+def test_check_deps_in_env_cleans_up_temp_file():
+    """The temp script file must be unlinked after the call returns."""
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["tmp_path"] = args[-1]
+        return CompletedProcess(args=args, returncode=0, stdout="{}\n", stderr="")
+
+    with patch("check_deps.subprocess.run", side_effect=fake_run):
+        check_deps.check_deps_in_env("conda")
+
+    assert not os.path.exists(captured["tmp_path"]), (
+        f"temp script file {captured['tmp_path']!r} was not cleaned up"
+    )
+
+
+def test_check_deps_in_env_cleans_up_temp_file_on_subprocess_error():
+    """Cleanup must run even if subprocess.run raises."""
+    captured = {}
+
+    def fake_run(args, **kwargs):
+        captured["tmp_path"] = args[-1]
+        raise OSError("simulated subprocess failure")
+
+    with patch("check_deps.subprocess.run", side_effect=fake_run):
+        with pytest.raises(OSError):
+            check_deps.check_deps_in_env("conda")
+
+    assert not os.path.exists(captured["tmp_path"]), (
+        f"temp script file {captured['tmp_path']!r} was not cleaned up after error"
+    )
 
 
 def test_main_parses_gpu_json_with_banner(capsys):


### PR DESCRIPTION
## Summary
- `check_deps_in_env()` passed a multi-line Python script to `conda run` via `python -c <script>`. On Windows, conda is a `.bat` wrapper invoked through `cmd.exe`, which mangles newline-bearing arguments — the inner Python received an empty payload, printed nothing, and every dep was reported MISSING even when installed.
- Fix: write the generated script to a `tempfile.mkstemp` `.py` file and invoke `python <tempfile>` instead, with `try/finally` cleanup. No other call sites needed changes — every other script in `scripts/` (including `check_gpu.py`) already invokes as a file.
- Adds three regression tests in `tests/test_check_deps.py` asserting the call shape: no `-c`, a `.py` temp file is passed, the file exists during the call, and is cleaned up after — including when `subprocess.run` raises.

## Test plan
- [x] `conda run -n video2pr python -m pytest tests/test_check_deps.py -v` — 22/22 pass (19 existing + 3 new regression tests)
- [x] Full suite: `conda run -n video2pr python -m pytest tests/ -q` — 113/113 pass
- [x] End-to-end on Windows (the original repro): `python scripts\check_deps.py` from PowerShell via `conda.BAT` — all four deps now report OK (`ffmpeg`, `ffprobe`, `faster-whisper`, `python-docx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)