### PR TITLE
[codex] Diagnose Windows CUDA transcription crashes

### DIFF
--- a/.agents/skills/video2pr/SKILL.md
+++ b/.agents/skills/video2pr/SKILL.md
@@ -59,8 +59,9 @@ After dependencies pass, check GPU status:
 ```
 
 Interpret the JSON output:
-- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue. This means a real CUDA inference smoke test passed, not just that CUDA was detected.
 - If `gpu_available` is `false` AND `install_command` is not null: display a **prominent warning** that a GPU is detected but CTranslate2 can't use CUDA yet, note the ~5-20x speedup that GPU acceleration provides, and **ask whether to install CUDA support now or continue with CPU**. Acting on it now — before any audio extraction or transcription — costs nothing; deferring means the user waits through the slow CPU path. If they agree, run the install command directly (e.g., `<conda-path> run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU-accelerated CTranslate2/CUDA support is active before proceeding.
+- If `gpu_available` is `false` AND `ct2_cuda_supported` is `true`: note that CTranslate2 reports CUDA support but the inference smoke test failed, so transcription will use `--device auto` and may fall back to CPU with diagnostics if CUDA crashes.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input

--- a/.claude/skills/video2pr/SKILL.md
+++ b/.claude/skills/video2pr/SKILL.md
@@ -60,8 +60,9 @@ After dependencies pass, check GPU status:
 ```
 
 Interpret the JSON output:
-- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue. This means a real CUDA inference smoke test passed, not just that CUDA was detected.
 - If `gpu_available` is `false` AND `install_command` is not null: display a **prominent warning** that a GPU is detected but CTranslate2 can't use CUDA yet, note the ~5-20x speedup that GPU acceleration provides, and **ask whether to install CUDA support now or continue with CPU**. Acting on it now — before any audio extraction or transcription — costs nothing; deferring means the user waits through the slow CPU path. If they agree, run the install command directly (e.g., `<conda-path> run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU-accelerated CTranslate2/CUDA support is active before proceeding.
+- If `gpu_available` is `false` AND `ct2_cuda_supported` is `true`: note that CTranslate2 reports CUDA support but the inference smoke test failed, so transcription will use `--device auto` and may fall back to CPU with diagnostics if CUDA crashes.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input

--- a/.github/skills/video2pr/SKILL.md
+++ b/.github/skills/video2pr/SKILL.md
@@ -59,8 +59,9 @@ After dependencies pass, check GPU status:
 ```
 
 Interpret the JSON output:
-- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue. This means a real CUDA inference smoke test passed, not just that CUDA was detected.
 - If `gpu_available` is `false` AND `install_command` is not null: display a **prominent warning** that a GPU is detected but CTranslate2 can't use CUDA yet, note the ~5-20x speedup that GPU acceleration provides, and **ask whether to install CUDA support now or continue with CPU**. Acting on it now — before any audio extraction or transcription — costs nothing; deferring means the user waits through the slow CPU path. If they agree, run the install command directly (e.g., `<conda-path> run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU-accelerated CTranslate2/CUDA support is active before proceeding.
+- If `gpu_available` is `false` AND `ct2_cuda_supported` is `true`: note that CTranslate2 reports CUDA support but the inference smoke test failed, so transcription will use `--device auto` and may fall back to CPU with diagnostics if CUDA crashes.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `--model` flag controls the quality/speed tradeoff for transcription:
 | `large-v3` | 1550M | ~0.5x realtime | Maximum accuracy, multilingual content |
 | `turbo` | 809M | ~3x realtime | Fast with good accuracy (faster-whisper only) |
 
-Speed estimates assume GPU acceleration. CPU-only runs are roughly 5-20x slower. The skill prompts you to install CUDA support if a compatible GPU is detected but not configured.
+Speed estimates assume GPU acceleration. CPU-only runs are roughly 5-20x slower. The skill prompts you to install CUDA support if a compatible GPU is detected but not configured. On Windows, CUDA is considered ready only after a tiny real inference smoke test succeeds; `nvidia-smi`, imports, and CTranslate2 supported compute types alone are not enough.
 
 ## Standalone Scripts
 
@@ -169,6 +169,17 @@ conda run -n video2pr pip install --upgrade ctranslate2
 ```
 
 After installing, re-run `python scripts/check_gpu.py` to confirm. If the GPU still isn't picked up, your NVIDIA driver may be older than what the current CTranslate2 wheel requires — check the [CTranslate2 release notes](https://github.com/OpenNMT/CTranslate2/releases) for the minimum driver version.
+
+</details>
+
+<details>
+<summary>CUDA is detected but transcription crashes or falls back to CPU on Windows</summary>
+
+Some CUDA failures happen inside CTranslate2's native runtime before Python can print a traceback. `scripts/check_gpu.py` now runs a tiny CUDA inference smoke test and reports CUDA as usable only when inference succeeds.
+
+If `--device cuda` fails, the script prints the child process exit code, package versions, CTranslate2 compute types, `nvidia-smi` details, and Windows PATH/DLL hints. If `--device auto` sees the same CUDA failure, it warns and retries on CPU so the transcription can continue.
+
+Common causes are incompatible or shadowed CUDA/cuDNN/cuBLAS DLLs, a CTranslate2 wheel/runtime mismatch, GPU memory pressure from another transcription, or an input-dependent native CTranslate2 failure. Keep using `--device auto` unless you specifically want CUDA failures to stop the run.
 
 </details>
 

--- a/install_video2pr.py
+++ b/install_video2pr.py
@@ -19,6 +19,7 @@ SCRIPT_NAMES = [
     "check_gpu.py",
     "check_update.py",
     "convert_transcript.py",
+    "diagnostics.py",
     "extract_audio.py",
     "extract_frame.py",
     "get_duration.py",

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -40,7 +40,7 @@ def parse_json_output(output: str):
             continue
         if line[end:].strip():
             continue
-        if not isinstance(value, dict | list):
+        if not isinstance(value, (dict, list)):  # noqa: UP038 - bootstrap Python may be <3.10.
             continue
         return value
 

--- a/scripts/check_deps.py
+++ b/scripts/check_deps.py
@@ -40,7 +40,7 @@ def parse_json_output(output: str):
             continue
         if line[end:].strip():
             continue
-        if not isinstance(value, (dict, list)):
+        if not isinstance(value, dict | list):
             continue
         return value
 
@@ -224,9 +224,13 @@ def main():
                 cuda_version = gpu_info.get("cuda_version")
                 available = gpu_info.get("gpu_available", False)
                 install_cmd = gpu_info.get("install_command")
+                ct2_cuda = gpu_info.get("ct2_cuda_supported", False)
 
                 if device == "cuda" and available:
                     print(f"  GPU: {gpu_name} (CUDA {cuda_version}) — OK")
+                    print("  GPU inference smoke test: OK")
+                elif gpu_name and ct2_cuda and not available:
+                    print(f"  GPU: {gpu_name} detected, but CUDA inference smoke test failed")
                 elif gpu_name and not available:
                     print(f"  GPU: {gpu_name} detected, CTranslate2 is CPU-only")
                     if install_cmd:

--- a/scripts/check_gpu.py
+++ b/scripts/check_gpu.py
@@ -5,12 +5,28 @@ Outputs structured JSON to stdout. Also exposes a check_gpu() function
 for programmatic use.
 """
 
+import contextlib
 import json
+import os
 import platform
 import re
 import shutil
 import subprocess
+import sys
+import tempfile
+import wave
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from diagnostics import (  # noqa: E402
+    PYTHON_EXCEPTION_MARKER,
+    classify_worker_failure,
+    collect_cuda_diagnostics,
+    tail_text,
+)
 
 
 def _find_nvidia_smi():
@@ -83,20 +99,110 @@ def _parse_cuda_version():
 def _check_ctranslate2_cuda():
     """Check if CTranslate2 (used by faster-whisper) supports CUDA.
 
-    Returns (installed, cuda_available).
+    Returns (installed, cuda_available, supported_compute_types).
     """
     try:
         import ctranslate2
 
         supported = ctranslate2.get_supported_compute_types("cuda")
-        return True, len(supported) > 0
+        return True, len(supported) > 0, sorted(supported)
     except (ImportError, RuntimeError, Exception):
         try:
-            import ctranslate2
+            import ctranslate2  # noqa: F401
 
-            return True, False
+            return True, False, []
         except ImportError:
-            return False, False
+            return False, False, []
+
+
+def _write_smoke_wav(path: Path) -> None:
+    """Write a tiny 16 kHz mono WAV for CUDA inference smoke tests."""
+    sample_rate = 16000
+    duration_seconds = 1
+    nframes = sample_rate * duration_seconds
+    silence = b"\x00\x00" * nframes
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(silence)
+
+
+def _run_cuda_inference_smoke_test(
+    model_name: str = "tiny",
+    compute_type: str = "float16",
+    timeout_seconds: int = 120,
+) -> dict:
+    """Run a real CUDA faster-whisper inference in a child process."""
+    fd, audio_name = tempfile.mkstemp(suffix=".wav")
+    os.close(fd)
+    audio_path = Path(audio_name)
+    script = f"""
+import faulthandler
+import sys
+import traceback
+
+faulthandler.enable(all_threads=True)
+try:
+    from faster_whisper import WhisperModel
+
+    print("SMOKE before model load", flush=True)
+    model = WhisperModel(sys.argv[1], device="cuda", compute_type=sys.argv[3])
+    print("SMOKE after model load", flush=True)
+    segments, info = model.transcribe(sys.argv[2], beam_size=1, vad_filter=False)
+    print("SMOKE after transcribe call", flush=True)
+    for _ in segments:
+        break
+    print("SMOKE_OK", flush=True)
+except BaseException as exc:
+    print("{PYTHON_EXCEPTION_MARKER}: " + type(exc).__name__ + ": " + str(exc), file=sys.stderr, flush=True)
+    traceback.print_exc()
+    sys.exit(1)
+"""
+    try:
+        _write_smoke_wav(audio_path)
+        result = subprocess.run(
+            [sys.executable, "-c", script, model_name, str(audio_path), compute_type],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+        ok = result.returncode == 0 and "SMOKE_OK" in (result.stdout or "")
+        failure_class = None
+        if not ok:
+            failure_class = classify_worker_failure(
+                result.returncode,
+                result.stdout or "",
+                result.stderr or "",
+            )
+        return {
+            "ok": ok,
+            "model": model_name,
+            "compute_type": compute_type,
+            "returncode": result.returncode,
+            "failure_class": failure_class,
+            "stdout_tail": tail_text(result.stdout, 2000),
+            "stderr_tail": tail_text(result.stderr, 2000),
+        }
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        return {
+            "ok": False,
+            "model": model_name,
+            "compute_type": compute_type,
+            "returncode": 124,
+            "failure_class": "timeout",
+            "stdout_tail": tail_text(stdout, 2000),
+            "stderr_tail": tail_text(stderr, 2000),
+        }
+    finally:
+        with contextlib.suppress(OSError):
+            Path(audio_name).unlink(missing_ok=True)
 
 
 def check_gpu():
@@ -115,10 +221,17 @@ def check_gpu():
     is_apple_silicon = plat == "Darwin" and arch == "arm64"
 
     # Check CTranslate2 (faster-whisper backend)
-    ct2_installed, ct2_cuda = _check_ctranslate2_cuda()
+    ct2_installed, ct2_cuda, ct2_supported = _check_ctranslate2_cuda()
+    smoke = {
+        "ok": False,
+        "skipped": True,
+        "reason": "No NVIDIA GPU with CTranslate2 CUDA support detected",
+    }
+    if gpu_name and ct2_cuda:
+        smoke = _run_cuda_inference_smoke_test()
 
     # Determine device and availability
-    if ct2_cuda and gpu_name:
+    if ct2_cuda and gpu_name and smoke.get("ok"):
         device = "cuda"
         gpu_available = True
     else:
@@ -135,6 +248,11 @@ def check_gpu():
     # Build message
     if device == "cuda":
         msg = f"GPU acceleration: {gpu_name} via CUDA {cuda_version or 'unknown'}"
+    elif gpu_name and ct2_cuda:
+        msg = (
+            f"GPU detected ({gpu_name}) and CTranslate2 reports CUDA support, "
+            "but CUDA inference smoke test failed"
+        )
     elif gpu_name:
         msg = f"GPU detected ({gpu_name}) but CUDA not available for CTranslate2"
     elif is_apple_silicon:
@@ -149,6 +267,16 @@ def check_gpu():
         "gpu_name": gpu_name,
         "cuda_version": cuda_version,
         "ct2_installed": ct2_installed,
+        "ct2_cuda_supported": ct2_cuda,
+        "ct2_supported_compute_types": ct2_supported,
+        "cuda_inference_usable": bool(smoke.get("ok")),
+        "cuda_smoke_test": smoke,
+        "diagnostics": collect_cuda_diagnostics(
+            device="cuda" if gpu_name and ct2_cuda else "cpu",
+            compute_type="float16" if gpu_name and ct2_cuda else "int8",
+            model_name=smoke.get("model", "tiny"),
+            operation="gpu_check_smoke_test",
+        ),
         "gpu_available": gpu_available,
         "install_command": install_command,
         "message": msg,

--- a/scripts/check_update.py
+++ b/scripts/check_update.py
@@ -17,6 +17,7 @@ SCRIPT_NAMES = [
     "check_gpu.py",
     "check_update.py",
     "convert_transcript.py",
+    "diagnostics.py",
     "extract_audio.py",
     "extract_frame.py",
     "get_duration.py",

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -1,0 +1,266 @@
+"""Runtime diagnostics shared by video2pr command-line scripts."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PYTHON_EXCEPTION_MARKER = "VIDEO2PR_PYTHON_EXCEPTION"
+
+CUDA_PACKAGE_NAMES = [
+    "faster-whisper",
+    "ctranslate2",
+    "nvidia-cublas-cu12",
+    "nvidia-cudnn-cu12",
+    "nvidia-cuda-runtime-cu12",
+    "nvidia-cuda-nvrtc-cu12",
+]
+
+
+def tail_text(text: str | None, limit: int = 4000) -> str:
+    """Return the tail of text for compact diagnostics."""
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return "...<truncated>...\n" + text[-limit:]
+
+
+def format_exit_code(returncode: int | None) -> str:
+    """Format a subprocess return code, including Windows native status codes."""
+    if returncode is None:
+        return "unknown"
+    if returncode < 0:
+        unsigned = returncode + (1 << 32)
+        return f"{returncode} (0x{unsigned:08X})"
+    if returncode > 255:
+        signed = returncode - (1 << 32) if returncode >= (1 << 31) else returncode
+        if signed != returncode:
+            return f"{returncode} (0x{returncode:08X}, signed {signed})"
+        return f"{returncode} (0x{returncode:08X})"
+    return str(returncode)
+
+
+def classify_worker_failure(
+    returncode: int | None,
+    stdout: str = "",
+    stderr: str = "",
+    timed_out: bool = False,
+) -> str:
+    """Classify a CUDA worker failure."""
+    if timed_out:
+        return "timeout"
+    combined = f"{stdout}\n{stderr}"
+    if PYTHON_EXCEPTION_MARKER in combined or "Traceback (most recent call last)" in combined:
+        return "python_exception"
+    if returncode not in (None, 0):
+        return "native_crash"
+    return "inference_failed"
+
+
+def find_nvidia_smi() -> str | None:
+    """Find nvidia-smi, including the common Windows system path."""
+    exe = shutil.which("nvidia-smi")
+    if exe is None and platform.system() == "Windows":
+        fallback = r"C:\Windows\System32\nvidia-smi.exe"
+        if Path(fallback).exists():
+            exe = fallback
+    return exe
+
+
+def query_nvidia_smi() -> dict:
+    """Return GPU, driver, and reported CUDA version from nvidia-smi when available."""
+    exe = find_nvidia_smi()
+    if exe is None:
+        return {"available": False}
+
+    info: dict = {"available": True, "path": exe}
+    try:
+        result = subprocess.run(
+            [exe, "--query-gpu=name,driver_version", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        info["query_returncode"] = result.returncode
+        if result.returncode == 0:
+            line = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 2:
+                info["gpu_name"] = parts[0]
+                info["driver_version"] = parts[1]
+        else:
+            info["query_stderr"] = tail_text(result.stderr, 1000)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        info["error"] = f"{type(exc).__name__}: {exc}"
+        return info
+
+    try:
+        header = subprocess.run([exe], capture_output=True, text=True, timeout=10)
+        info["header_returncode"] = header.returncode
+        if header.returncode == 0:
+            match = re.search(r"CUDA Version:\s+([\d.]+)", header.stdout)
+            if match:
+                info["cuda_version"] = match.group(1)
+        else:
+            info["header_stderr"] = tail_text(header.stderr, 1000)
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        info["header_error"] = f"{type(exc).__name__}: {exc}"
+
+    return info
+
+
+def package_versions() -> dict[str, str | None]:
+    """Return relevant package versions without requiring every package to be installed."""
+    versions = {}
+    for package in CUDA_PACKAGE_NAMES:
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = None
+    return versions
+
+
+def ctranslate2_cuda_info() -> dict:
+    """Return CTranslate2 import status and supported CUDA compute types."""
+    try:
+        import ctranslate2
+
+        info = {
+            "installed": True,
+            "version": getattr(ctranslate2, "__version__", None),
+        }
+        try:
+            supported = ctranslate2.get_supported_compute_types("cuda")
+            info["cuda_supported_compute_types"] = sorted(supported)
+            info["cuda_supported"] = bool(supported)
+        except Exception as exc:  # noqa: BLE001 - diagnostic path should not hide details.
+            info["cuda_supported_compute_types"] = []
+            info["cuda_supported"] = False
+            info["cuda_error"] = f"{type(exc).__name__}: {exc}"
+        return info
+    except Exception as exc:  # noqa: BLE001 - import diagnostics should capture all failures.
+        return {
+            "installed": False,
+            "cuda_supported": False,
+            "cuda_supported_compute_types": [],
+            "import_error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def windows_path_hints() -> dict:
+    """Return Windows PATH entries likely to affect CUDA DLL resolution."""
+    if platform.system() != "Windows":
+        return {}
+    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    keywords = ("cuda", "cudnn", "nvidia", "ctranslate", "torch")
+    matching = [entry for entry in entries if any(k in entry.lower() for k in keywords)]
+    return {
+        "python_executable": sys.executable,
+        "path_entries_with_cuda_keywords": matching[:30],
+        "hint": (
+            "On Windows, native CUDA crashes often come from CUDA, cuDNN, or cuBLAS DLLs "
+            "being missing, shadowed, or incompatible with the installed CTranslate2 wheel."
+        ),
+    }
+
+
+def collect_cuda_diagnostics(
+    device: str,
+    compute_type: str,
+    model_name: str,
+    operation: str,
+) -> dict:
+    """Collect actionable CUDA runtime diagnostics."""
+    return {
+        "operation": operation,
+        "selected_device": device,
+        "selected_compute_type": compute_type,
+        "model": model_name,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "python": sys.version.replace("\n", " "),
+            "python_executable": sys.executable,
+        },
+        "packages": package_versions(),
+        "ctranslate2": ctranslate2_cuda_info(),
+        "nvidia_smi": query_nvidia_smi(),
+        "windows_dll_path_hints": windows_path_hints(),
+    }
+
+
+def format_cuda_failure_report(
+    *,
+    operation: str,
+    failure_class: str,
+    returncode: int | None,
+    stdout: str,
+    stderr: str,
+    diagnostics: dict,
+) -> str:
+    """Build a readable CUDA failure report for stderr."""
+    lines = [
+        "CUDA inference failed.",
+        f"  operation: {operation}",
+        f"  failure_class: {failure_class}",
+        f"  child_exit_code: {format_exit_code(returncode)}",
+        f"  selected_device: {diagnostics.get('selected_device')}",
+        f"  selected_compute_type: {diagnostics.get('selected_compute_type')}",
+        f"  model: {diagnostics.get('model')}",
+    ]
+
+    packages = diagnostics.get("packages", {})
+    if packages:
+        lines.append("  packages:")
+        for name, version in packages.items():
+            lines.append(f"    {name}: {version or 'not installed'}")
+
+    ct2 = diagnostics.get("ctranslate2", {})
+    lines.append(
+        f"  ctranslate2_cuda_supported_compute_types: {ct2.get('cuda_supported_compute_types', [])}"
+    )
+
+    smi = diagnostics.get("nvidia_smi", {})
+    if smi.get("gpu_name"):
+        lines.append(
+            "  nvidia_smi: "
+            f"{smi.get('gpu_name')} driver={smi.get('driver_version')} "
+            f"cuda={smi.get('cuda_version', 'unknown')}"
+        )
+    elif smi.get("available"):
+        lines.append(f"  nvidia_smi: available at {smi.get('path')}, query incomplete")
+    else:
+        lines.append("  nvidia_smi: not found")
+
+    hints = diagnostics.get("windows_dll_path_hints", {})
+    if hints:
+        lines.append(f"  dll_hint: {hints.get('hint')}")
+        path_entries = hints.get("path_entries_with_cuda_keywords") or []
+        if path_entries:
+            lines.append("  PATH entries with CUDA/NVIDIA keywords:")
+            for entry in path_entries[:10]:
+                lines.append(f"    {entry}")
+        else:
+            lines.append("  PATH entries with CUDA/NVIDIA keywords: none found")
+
+    out_tail = tail_text(stdout)
+    err_tail = tail_text(stderr)
+    if out_tail:
+        lines.extend(["  child_stdout_tail:", indent_block(out_tail, "    ")])
+    if err_tail:
+        lines.extend(["  child_stderr_tail:", indent_block(err_tail, "    ")])
+
+    return "\n".join(lines)
+
+
+def indent_block(text: str, prefix: str) -> str:
+    """Indent each line in a block."""
+    return "\n".join(prefix + line for line in text.splitlines())

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -2,11 +2,32 @@
 """Transcribe audio using faster-whisper with built-in VAD and word timestamps."""
 
 import argparse
+import contextlib
+import faulthandler
+import importlib.util
 import json
+import os
 import re
+import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from diagnostics import (  # noqa: E402
+    PYTHON_EXCEPTION_MARKER,
+    classify_worker_failure,
+    collect_cuda_diagnostics,
+    format_cuda_failure_report,
+)
+
+CUDA_WORKER_ARG = "--_video2pr-worker"
+CUDA_WORKER_TIMEOUT_SECONDS = 60 * 60 * 12
+REQUIRED_RUNTIME_MODULES = {"faster-whisper": "faster_whisper"}
 
 
 def format_elapsed(seconds: float) -> str:
@@ -72,9 +93,35 @@ def load_model(model_name: str, device: str = "auto", compute_type: str = "defau
     return WhisperModel(model_name, device=resolved_device, compute_type=resolved_compute)
 
 
-def detect_language(audio_path: Path, model_name: str = "base", device: str = "auto") -> dict:
+def ensure_runtime_dependencies() -> None:
+    """Fail early when the script is not running in the video2pr environment."""
+    missing = [
+        package
+        for package, module_name in REQUIRED_RUNTIME_MODULES.items()
+        if importlib.util.find_spec(module_name) is None
+    ]
+    if not missing:
+        return
+
+    print(
+        "Missing runtime dependency: "
+        f"{', '.join(missing)}. Run this script inside the video2pr environment.",
+        file=sys.stderr,
+    )
+    print(f"Current Python: {sys.executable}", file=sys.stderr)
+    print("Expected usage:", file=sys.stderr)
+    print("  conda run -n video2pr python scripts/transcribe.py ...", file=sys.stderr)
+    sys.exit(1)
+
+
+def detect_language(
+    audio_path: Path,
+    model_name: str = "base",
+    device: str = "auto",
+    compute_type: str = "default",
+) -> dict:
     """Detect language from audio using faster-whisper."""
-    model = load_model(model_name, device=device)
+    model = load_model(model_name, device=device, compute_type=compute_type)
 
     # Use faster-whisper's built-in language detection
     segments, info = model.transcribe(
@@ -227,8 +274,8 @@ def _get_audio_duration(audio_path: Path) -> float | None:
         return None
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Transcribe audio using faster-whisper")
+def _add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Configure command-line arguments."""
     parser.add_argument("--input", required=True, help="Path to input audio file")
     parser.add_argument("--output-dir", help="Output directory (required unless --detect-language)")
     parser.add_argument(
@@ -263,8 +310,15 @@ def main():
         action="store_true",
         help="Detect language from audio and output JSON to stdout",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        CUDA_WORKER_ARG,
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
 
+
+def _run_cli(args: argparse.Namespace) -> None:
+    """Run the requested command in the current process."""
     audio_path = Path(args.input).resolve()
 
     if not audio_path.exists():
@@ -273,7 +327,12 @@ def main():
 
     # Language detection mode
     if args.detect_language:
-        result = detect_language(audio_path, model_name="base", device=args.device)
+        result = detect_language(
+            audio_path,
+            model_name="base",
+            device=args.device,
+            compute_type=args.compute_type,
+        )
         print(json.dumps(result, indent=2))
         return
 
@@ -295,6 +354,156 @@ def main():
     )
 
     print("Transcription complete.")
+
+
+def _operation_name(args: argparse.Namespace) -> str:
+    return "language_detection" if args.detect_language else "transcription"
+
+
+def _worker_command(args: argparse.Namespace, device: str) -> list[str]:
+    """Build a child process command for isolated CUDA execution."""
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        CUDA_WORKER_ARG,
+        "--input",
+        str(Path(args.input).resolve()),
+        "--device",
+        device,
+        "--compute-type",
+        args.compute_type,
+    ]
+    if args.output_dir:
+        cmd.extend(["--output-dir", str(Path(args.output_dir).resolve())])
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.language:
+        cmd.extend(["--language", args.language])
+    if args.no_vad:
+        cmd.append("--no-vad")
+    if args.detect_language:
+        cmd.append("--detect-language")
+    return cmd
+
+
+def _run_cuda_worker(args: argparse.Namespace) -> subprocess.CompletedProcess[str] | None:
+    """Run a CUDA operation in a child process so native crashes are observable."""
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    cmd = _worker_command(args, "cuda")
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=CUDA_WORKER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        return subprocess.CompletedProcess(cmd, 124, stdout=stdout, stderr=stderr)
+
+
+def _print_child_output(result: subprocess.CompletedProcess[str]) -> None:
+    """Relay child stdout/stderr to the parent streams."""
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+
+def _cuda_failure_report(
+    args: argparse.Namespace,
+    result: subprocess.CompletedProcess[str],
+) -> str:
+    operation = _operation_name(args)
+    resolved_device, resolved_compute = resolve_device("cuda")
+    if args.compute_type != "default":
+        resolved_compute = args.compute_type
+    diagnostics = collect_cuda_diagnostics(
+        device=resolved_device,
+        compute_type=resolved_compute,
+        model_name="base" if args.detect_language else args.model,
+        operation=operation,
+    )
+    failure_class = classify_worker_failure(
+        result.returncode,
+        result.stdout or "",
+        result.stderr or "",
+        timed_out=result.returncode == 124,
+    )
+    return format_cuda_failure_report(
+        operation=operation,
+        failure_class=failure_class,
+        returncode=result.returncode,
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+        diagnostics=diagnostics,
+    )
+
+
+def _run_parent(args: argparse.Namespace) -> None:
+    """Run the CLI, isolating CUDA so native crashes cannot be silent."""
+    if args.device == "cpu":
+        _run_cli(args)
+        return
+
+    result = _run_cuda_worker(args)
+    if result is None:
+        print("Internal error: CUDA worker did not return a result.", file=sys.stderr)
+        sys.exit(1)
+
+    if result.returncode == 0:
+        _print_child_output(result)
+        return
+
+    report = _cuda_failure_report(args, result)
+    if args.device == "cuda":
+        print(report, file=sys.stderr)
+        sys.exit(1)
+
+    print(report, file=sys.stderr)
+    print(
+        "WARNING: CUDA inference failed under --device auto; retrying on CPU.",
+        file=sys.stderr,
+    )
+    args.device = "cpu"
+    _run_cli(args)
+
+
+def _run_worker(args: argparse.Namespace) -> None:
+    """Run child worker code with Python exception reporting enabled."""
+    with contextlib.suppress(Exception):
+        faulthandler.enable(all_threads=True)
+    try:
+        _run_cli(args)
+    except BaseException as exc:
+        print(
+            f"{PYTHON_EXCEPTION_MARKER}: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+        traceback.print_exc()
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe audio using faster-whisper")
+    _add_arguments(parser)
+    args = parser.parse_args()
+
+    ensure_runtime_dependencies()
+
+    if args._video2pr_worker:
+        _run_worker(args)
+        return
+
+    _run_parent(args)
 
 
 if __name__ == "__main__":

--- a/scripts/transcribe.py
+++ b/scripts/transcribe.py
@@ -409,6 +409,29 @@ def _run_cuda_worker(args: argparse.Namespace) -> subprocess.CompletedProcess[st
         return subprocess.CompletedProcess(cmd, 124, stdout=stdout, stderr=stderr)
 
 
+def _auto_should_try_cuda() -> bool:
+    """Return whether --device auto should prefer the isolated CUDA path."""
+    try:
+        import ctranslate2
+
+        if not ctranslate2.get_supported_compute_types("cuda"):
+            return False
+    except Exception:
+        return False
+
+    try:
+        smi = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+
+    return smi.returncode == 0 and bool(smi.stdout.strip())
+
+
 def _print_child_output(result: subprocess.CompletedProcess[str]) -> None:
     """Relay child stdout/stderr to the parent streams."""
     if result.stdout:
@@ -450,6 +473,10 @@ def _cuda_failure_report(
 def _run_parent(args: argparse.Namespace) -> None:
     """Run the CLI, isolating CUDA so native crashes cannot be silent."""
     if args.device == "cpu":
+        _run_cli(args)
+        return
+
+    if args.device == "auto" and not _auto_should_try_cuda():
         _run_cli(args)
         return
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -46,8 +46,9 @@ After dependencies pass, check GPU status:
 ```
 
 Interpret the JSON output:
-- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue.
+- If `gpu_available` is `true`: report the GPU (e.g., "GPU acceleration: NVIDIA RTX 3080 via CUDA 12.4") and continue. This means a real CUDA inference smoke test passed, not just that CUDA was detected.
 - If `gpu_available` is `false` AND `install_command` is not null: display a **prominent warning** that a GPU is detected but CTranslate2 can't use CUDA yet, note the ~5-20x speedup that GPU acceleration provides, and **ask whether to install CUDA support now or continue with CPU**. Acting on it now — before any audio extraction or transcription — costs nothing; deferring means the user waits through the slow CPU path. If they agree, run the install command directly (e.g., `<conda-path> run -n video2pr <install_command>`) — do NOT just show the command for the user to run manually. After installation, re-run `check_gpu.py` to confirm GPU-accelerated CTranslate2/CUDA support is active before proceeding.
+- If `gpu_available` is `false` AND `ct2_cuda_supported` is `true`: note that CTranslate2 reports CUDA support but the inference smoke test failed, so transcription will use `--device auto` and may fall back to CPU with diagnostics if CUDA crashes.
 - If `device` is `"cpu"` and `install_command` is null: note "Running on CPU" and continue silently.
 
 ## Phase 2: Validate Input

--- a/tests/test_check_gpu.py
+++ b/tests/test_check_gpu.py
@@ -48,13 +48,92 @@ def test_nvidia_cuda_working(monkeypatch):
         ["float16", "int8"] if device == "cuda" else ["int8"]
     )
     monkeypatch.setitem(sys.modules, "ctranslate2", fake_ct2)
+    monkeypatch.setattr(
+        gpu,
+        "_run_cuda_inference_smoke_test",
+        lambda: {
+            "ok": True,
+            "model": "tiny",
+            "compute_type": "float16",
+            "returncode": 0,
+            "failure_class": None,
+            "stdout_tail": "SMOKE_OK",
+            "stderr_tail": "",
+        },
+    )
 
     result = gpu.check_gpu()
     assert result["device"] == "cuda"
     assert result["gpu_available"] is True
+    assert result["cuda_inference_usable"] is True
+    assert result["ct2_cuda_supported"] is True
     assert result["install_command"] is None
     assert result["gpu_name"] == "NVIDIA RTX 3080"
     assert result["cuda_version"] == "12.4"
+
+
+def test_nvidia_cuda_supported_but_smoke_crashes(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr("platform.machine", lambda: "AMD64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(subprocess, "run", _fake_nvidia_smi())
+
+    fake_ct2 = types.ModuleType("ctranslate2")
+    fake_ct2.get_supported_compute_types = lambda device: (
+        ["float16", "int8"] if device == "cuda" else ["int8"]
+    )
+    monkeypatch.setitem(sys.modules, "ctranslate2", fake_ct2)
+    monkeypatch.setattr(
+        gpu,
+        "_run_cuda_inference_smoke_test",
+        lambda: {
+            "ok": False,
+            "model": "tiny",
+            "compute_type": "float16",
+            "returncode": -1073740791,
+            "failure_class": "native_crash",
+            "stdout_tail": "SMOKE before model load",
+            "stderr_tail": "",
+        },
+    )
+
+    result = gpu.check_gpu()
+    assert result["device"] == "cpu"
+    assert result["gpu_available"] is False
+    assert result["ct2_cuda_supported"] is True
+    assert result["cuda_inference_usable"] is False
+    assert result["cuda_smoke_test"]["failure_class"] == "native_crash"
+    assert result["cuda_smoke_test"]["returncode"] == -1073740791
+    assert "smoke test failed" in result["message"]
+
+
+def test_nvidia_cuda_supported_but_smoke_python_exception(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr("platform.machine", lambda: "AMD64")
+    monkeypatch.setattr("shutil.which", lambda x: "/usr/bin/nvidia-smi")
+    monkeypatch.setattr(subprocess, "run", _fake_nvidia_smi())
+
+    fake_ct2 = types.ModuleType("ctranslate2")
+    fake_ct2.get_supported_compute_types = lambda device: ["float16"] if device == "cuda" else []
+    monkeypatch.setitem(sys.modules, "ctranslate2", fake_ct2)
+    monkeypatch.setattr(
+        gpu,
+        "_run_cuda_inference_smoke_test",
+        lambda: {
+            "ok": False,
+            "model": "tiny",
+            "compute_type": "float16",
+            "returncode": 1,
+            "failure_class": "python_exception",
+            "stdout_tail": "",
+            "stderr_tail": "VIDEO2PR_PYTHON_EXCEPTION: RuntimeError: boom",
+        },
+    )
+
+    result = gpu.check_gpu()
+    assert result["gpu_available"] is False
+    assert result["cuda_smoke_test"]["failure_class"] == "python_exception"
+    assert "VIDEO2PR_PYTHON_EXCEPTION" in result["cuda_smoke_test"]["stderr_tail"]
 
 
 def test_nvidia_ct2_cpu_only(monkeypatch):

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -106,7 +106,7 @@ def test_full_pipeline_produces_valid_transcript_json(tmp_path):
     assert isinstance(payload["segments"], list)
 
     for seg in payload["segments"]:
-        assert "start" in seg and isinstance(seg["start"], (int, float))
-        assert "end" in seg and isinstance(seg["end"], (int, float))
+        assert "start" in seg and isinstance(seg["start"], int | float)
+        assert "end" in seg and isinstance(seg["end"], int | float)
         assert "text" in seg and isinstance(seg["text"], str)
         assert "words" in seg and isinstance(seg["words"], list)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -100,8 +100,8 @@ def test_install_claude_code(fake_repo, target_dir, monkeypatch):
     installed = install.install_assistant(target_dir, "claude-code", dry_run=False)
 
     skill_dir = target_dir / ".claude" / "skills" / "video2pr"
-    # 8 scripts + env + SKILL.md + config
-    assert len(installed) == 11
+    # 9 scripts + env + SKILL.md + config
+    assert len(installed) == 12
     assert (skill_dir / "scripts" / "transcribe.py").exists()
     assert (skill_dir / "environment.yml").exists()
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -96,6 +96,7 @@ def test_device_auto_falls_back_to_cpu_when_cuda_worker_native_crashes(monkeypat
     args = _args(device="auto")
     calls = []
 
+    monkeypatch.setattr(tr, "_auto_should_try_cuda", lambda: True)
     monkeypatch.setattr(
         tr,
         "_run_cuda_worker",
@@ -122,6 +123,54 @@ def test_device_auto_falls_back_to_cpu_when_cuda_worker_native_crashes(monkeypat
     assert "0xC0000409" in captured.err
     assert "signed -1073740791" in captured.err
     assert "retrying on CPU" in captured.err
+    assert '"language": "pt"' in captured.out
+
+
+def test_device_auto_skips_cuda_worker_when_cuda_is_not_candidate(monkeypatch):
+    args = _args(device="auto")
+    calls = []
+
+    monkeypatch.setattr(tr, "_auto_should_try_cuda", lambda: False)
+
+    def fail_cuda_worker(run_args):
+        raise AssertionError("auto should not force cuda on CPU-only hosts")
+
+    def fake_run_cli(run_args):
+        calls.append(run_args.device)
+
+    monkeypatch.setattr(tr, "_run_cuda_worker", fail_cuda_worker)
+    monkeypatch.setattr(tr, "_run_cli", fake_run_cli)
+
+    tr._run_parent(args)
+
+    assert calls == ["auto"]
+
+
+def test_device_auto_prefers_cuda_worker_when_cuda_is_candidate(monkeypatch, capsys):
+    args = _args(device="auto")
+    calls = []
+
+    monkeypatch.setattr(tr, "_auto_should_try_cuda", lambda: True)
+    monkeypatch.setattr(
+        tr,
+        "_run_cuda_worker",
+        lambda args: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"language": "pt", "confidence": 0.96}\n',
+            stderr="",
+        ),
+    )
+
+    def fake_run_cli(run_args):
+        calls.append(run_args.device)
+
+    monkeypatch.setattr(tr, "_run_cli", fake_run_cli)
+
+    tr._run_parent(args)
+
+    captured = capsys.readouterr()
+    assert calls == []
     assert '"language": "pt"' in captured.out
 
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,6 +1,8 @@
 """Tests for scripts/transcribe.py — pure function tests only."""
 
+import argparse
 import json
+import subprocess
 
 import pytest
 from conftest import import_script
@@ -58,6 +60,123 @@ def test_resolve_device_cpu():
 
 
 # ── Custom SRT writer ──────────────────────────────────────────────
+
+
+def _args(device="auto"):
+    return argparse.Namespace(
+        input="audio.wav",
+        output_dir=None,
+        model="small",
+        language=None,
+        device=device,
+        compute_type="default",
+        no_vad=False,
+        detect_language=True,
+        _video2pr_worker=False,
+    )
+
+
+def _fake_diagnostics():
+    return {
+        "selected_device": "cuda",
+        "selected_compute_type": "float16",
+        "model": "base",
+        "packages": {"faster-whisper": "1.2.1", "ctranslate2": "4.7.1"},
+        "ctranslate2": {"cuda_supported_compute_types": ["float16"]},
+        "nvidia_smi": {
+            "gpu_name": "RTX 4070 Laptop GPU",
+            "driver_version": "596.08",
+            "cuda_version": "13.2",
+        },
+        "windows_dll_path_hints": {},
+    }
+
+
+def test_device_auto_falls_back_to_cpu_when_cuda_worker_native_crashes(monkeypatch, capsys):
+    args = _args(device="auto")
+    calls = []
+
+    monkeypatch.setattr(
+        tr,
+        "_run_cuda_worker",
+        lambda args: subprocess.CompletedProcess(
+            args=[],
+            returncode=3221226505,
+            stdout="Loading Whisper model 'base' (device=cuda, compute=float16)...\n",
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(tr, "collect_cuda_diagnostics", lambda **kwargs: _fake_diagnostics())
+
+    def fake_run_cli(run_args):
+        calls.append(run_args.device)
+        print('{"language": "pt", "confidence": 0.96}')
+
+    monkeypatch.setattr(tr, "_run_cli", fake_run_cli)
+
+    tr._run_parent(args)
+
+    captured = capsys.readouterr()
+    assert calls == ["cpu"]
+    assert "failure_class: native_crash" in captured.err
+    assert "0xC0000409" in captured.err
+    assert "signed -1073740791" in captured.err
+    assert "retrying on CPU" in captured.err
+    assert '"language": "pt"' in captured.out
+
+
+def test_device_cuda_fails_loudly_when_worker_native_crashes(monkeypatch, capsys):
+    args = _args(device="cuda")
+
+    monkeypatch.setattr(
+        tr,
+        "_run_cuda_worker",
+        lambda args: subprocess.CompletedProcess(
+            args=[],
+            returncode=-1073740791,
+            stdout="Loading Whisper model 'base' (device=cuda, compute=float16)...\n",
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(tr, "collect_cuda_diagnostics", lambda **kwargs: _fake_diagnostics())
+
+    with pytest.raises(SystemExit) as exc_info:
+        tr._run_parent(args)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "CUDA inference failed." in captured.err
+    assert "failure_class: native_crash" in captured.err
+    assert "child_stdout_tail" in captured.err
+
+
+def test_worker_prints_python_exception_marker(monkeypatch, capsys):
+    args = _args(device="cuda")
+
+    def raise_error(run_args):
+        raise RuntimeError("cuda load failed")
+
+    monkeypatch.setattr(tr, "_run_cli", raise_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        tr._run_worker(args)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert tr.PYTHON_EXCEPTION_MARKER in captured.err
+    assert "RuntimeError: cuda load failed" in captured.err
+
+
+def test_missing_runtime_dependency_points_to_video2pr_env(monkeypatch, capsys):
+    monkeypatch.setattr(tr.importlib.util, "find_spec", lambda module_name: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        tr.ensure_runtime_dependencies()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "Missing runtime dependency: faster-whisper" in captured.err
+    assert "conda run -n video2pr" in captured.err
 
 
 def test_write_transcript_srt(tmp_path):


### PR DESCRIPTION
﻿## Summary

- Isolate CUDA transcription/language-detection work in a child process so native CTranslate2 crashes are classified instead of silently killing the parent.
- Add shared diagnostics for CUDA failures, including package versions, CTranslate2 compute types, `nvidia-smi`, Windows DLL/PATH hints, and decoded native exit codes.
- Make `check_gpu.py` report GPU availability only after a real tiny CUDA inference smoke test succeeds.
- Add `--device auto` CPU fallback when CUDA inference crashes, while keeping explicit `--device cuda` as a loud failure.
- Add an early runtime dependency check so scripts run outside the `video2pr` env point users to `conda run -n video2pr ...`.

## Root Cause / Context

The reproduced failure was a native Windows CUDA abort during faster-whisper language detection. It printed only:

```text
Loading Whisper model 'base' (device=cuda, compute=float16)...
```

and exited with Windows status `0xC0000409` / signed `-1073740791`, so normal Python exception handling could not catch it in-process.

## Validation

- Reproduced the original failing command against the reported `audio.wav`.
- Verified fixed `--device cuda` fails loudly with `failure_class: native_crash` and decoded exit code.
- Verified fixed `--device auto` warns, falls back to CPU, and completes language detection.
- Verified wrong Python environment now fails early with `conda run -n video2pr` guidance.
- `pytest -q --ignore=tests/test_e2e_pipeline.py` -> 117 passed
- `ruff check .` -> passed
- `ruff format --check .` -> passed
- `python scripts/sync_skill.py --check` -> passed
- Docker Linux `python:3.13-slim`: tests/lint/format/sync passed

## Notes

Docker cannot provide native macOS runtime verification. macOS-specific branches remain covered by the existing platform-mocked tests.
